### PR TITLE
Expand tracing to remaining modules

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,7 +94,7 @@ impl Config {
 
                 // Save S2P file
                 if let Err(e) = result.save(&output_s2p_path) {
-                    eprintln!("Failed to save S2P file: {}", e);
+                    tracing::error!("Failed to save S2P file: {}", e);
                     // Continue to plot generation? Or return error?
                     // Let's return error.
                     return Err("Failed to save S2P file");
@@ -258,7 +258,7 @@ fn parse_plot_open_in_browser(file_path: String) {
             }
         }
         if networks.is_empty() {
-            eprintln!("No valid network files found in directory.");
+            tracing::warn!("No valid network files found in directory.");
         }
         // Output HTML in the directory
         let output_html_path = path

--- a/src/data_line.rs
+++ b/src/data_line.rs
@@ -79,7 +79,7 @@ pub(crate) fn parse_data_line(
         // println!("Converting frequency from THz to Hz");
         // println!("Original frequency: {} THz", frequency);
         frequency = rfconversions::frequency::thz_to_hz(frequency);
-        println!("Converted frequency: {} Hz", frequency);
+        tracing::trace!("Converted frequency: {} Hz", frequency);
     } else if frequency_unit == "GHz" {
         // convert to Hz
         // println!("Converting frequency from GHz to Hz");

--- a/src/file_operations.rs
+++ b/src/file_operations.rs
@@ -15,7 +15,7 @@ pub fn get_file_path_config(path_str: &str) -> FilePathConfig {
 
     if path.is_absolute() {
         // /home/user/files/measured.s2p, etc.
-        println!("'{}' is an Absolute path.", path_str);
+        tracing::debug!("Absolute path: {}", path_str);
         FilePathConfig {
             absolute_path: true,
             relative_path_with_separators: false,
@@ -25,10 +25,7 @@ pub fn get_file_path_config(path_str: &str) -> FilePathConfig {
     // If it's not absolute, we check the number of parts
     else if path.components().count() > 1 {
         // files/measured.s2p, etc.
-        println!(
-            "'{}' is a Relative path with separators (nested).",
-            path_str
-        );
+        tracing::debug!("Relative path with separators: {}", path_str);
         FilePathConfig {
             absolute_path: false,
             relative_path_with_separators: true,
@@ -36,7 +33,7 @@ pub fn get_file_path_config(path_str: &str) -> FilePathConfig {
         }
     } else {
         // measured.s2p, etc.
-        println!("'{}' is a Bare filename (no separators).", path_str);
+        tracing::debug!("Bare filename: {}", path_str);
         FilePathConfig {
             absolute_path: false,
             relative_path_with_separators: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,7 +682,7 @@ impl ops::Mul<Network> for Network {
     type Output = Network;
 
     fn mul(self, _rhs: Network) -> Network {
-        println!("> Network.mul(Network) was called");
+        tracing::debug!("Network cascade (mul) operation");
 
         self.cascade(&_rhs)
     }

--- a/src/open.rs
+++ b/src/open.rs
@@ -20,8 +20,8 @@ pub fn browser(url: &str) {
     // .spawn() creates the child process and returns immediately.
     // We do NOT use .output() because that would wait for the browser to close.
     match process::Command::new(cmd).args(&args).spawn() {
-        Ok(_) => println!("Success! Opening: {}", url),
-        Err(e) => eprintln!("Failed to open {} in your default browser: {}", url, e),
+        Ok(_) => tracing::info!("Opening in browser: {}", url),
+        Err(e) => tracing::error!("Failed to open {} in default browser: {}", url, e),
     }
 }
 
@@ -32,16 +32,13 @@ pub fn plot(file_path: String) {
     // which most modern browsers can handle, but strictly speaking is invalid URI syntax.
     let html_file_url = file_operations::get_file_url(&file_path);
 
-    println!(
-        "You can open the plot in your browser at:\n{}",
-        html_file_url
-    );
+    tracing::info!("Plot available at: {}", html_file_url);
 
     // if not part of cargo test, open the created file
     if cfg!(test) {
         // pass
     } else {
-        println!("Attempting to open plot in your default browser...");
+        tracing::debug!("Attempting to open plot in default browser...");
         // 2. Use the open crate to launch the file, if not testing
         browser(&html_file_url);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,6 +13,7 @@ struct ParserState {
 }
 
 pub fn read_file(file_path: String) -> Network {
+    tracing::debug!("Parsing touchstone file: {}", file_path);
     let contents = fs::read_to_string(&file_path).expect("Should have been able to read the file");
 
     let file_type = file_path
@@ -138,7 +139,13 @@ pub fn read_file(file_path: String) -> Network {
         parser_state.data_lines.extend(current_data_segment);
     }
 
-    // println!("parsed options:\n{:?}", parsed_options);
+    tracing::debug!(
+        num_ports = n_ports,
+        num_frequencies = f.len(),
+        format = %parsed_options.format,
+        frequency_unit = %parsed_options.frequency_unit,
+        "Parsing complete"
+    );
 
     Network {
         name: file_path,

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -167,6 +167,12 @@ pub fn generate_plot_from_networks(
     }
 
     let rank = networks[0].rank;
+    tracing::debug!(
+        num_networks = networks.len(),
+        rank,
+        output_path,
+        "Generating plot"
+    );
 
     // Verify all networks have the same rank
     for network in networks {


### PR DESCRIPTION
## Summary

Follow-up to #47 — Codex assessed all source files and identified modules needing additional tracing.

## Codex Assessment Results

| File | Action | Rationale |
|---|---|---|
| `parser.rs` | ✅ Added | Multi-step file parsing with format/unit conversion — debug at start/complete |
| `plot.rs` | ✅ Added | File I/O and rank validation — debug at generation start |
| `open.rs` | ✅ Converted | Remaining println → tracing |
| `file_operations.rs` | ✅ Converted | Remaining println → tracing::debug |
| `data_line.rs` | ✅ Converted | Frequency unit conversion println → tracing::trace |
| `lib.rs` | ✅ Converted | Network cascade mul println → tracing::debug |
| `cli.rs` | ✅ Converted | eprintln → tracing::error/warn |
| `print_summary()` | ⏭️ Skip | Intentional user-facing output |
| `data_pairs.rs` | ⏭️ Skip | Pure math primitives |
| `utils.rs` | ⏭️ Skip | Tiny helpers |
| `file_extension.rs` | ⏭️ Skip | Simple validation |
| `option_line.rs` | ⏭️ Skip | Low complexity |

All 166 tests pass.