### PR TITLE
Fix warnings, add 9 save/cascade tests (175 total)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1059,39 +1059,192 @@ mod tests {
         let network2 = Network::new("files/ntwk2.s2p".to_string());
 
         // This should panic because we don't support 1→2 connection yet
-        network1.cascade_ports(&network2, 1, 2);
+        let _ = network1.cascade_ports(&network2, 1, 2);
     }
 
     #[test]
     #[should_panic(expected = "from_port 3 out of range for 2-port network")]
     fn test_cascade_ports_invalid_from_port() {
-        // Test that invalid from_port is caught
         let network1 = Network::new("files/ntwk1.s2p".to_string());
         let network2 = Network::new("files/ntwk2.s2p".to_string());
-
-        // This should panic - port 3 doesn't exist on 2-port network
-        network1.cascade_ports(&network2, 3, 1);
+        let _ = network1.cascade_ports(&network2, 3, 1);
     }
 
     #[test]
     #[should_panic(expected = "to_port 5 out of range for 2-port network")]
     fn test_cascade_ports_invalid_to_port() {
-        // Test that invalid to_port is caught
         let network1 = Network::new("files/ntwk1.s2p".to_string());
         let network2 = Network::new("files/ntwk2.s2p".to_string());
-
-        // This should panic - port 5 doesn't exist on 2-port network
-        network1.cascade_ports(&network2, 2, 5);
+        let _ = network1.cascade_ports(&network2, 2, 5);
     }
 
     #[test]
     #[should_panic(expected = "from_port 0 out of range")]
     fn test_cascade_ports_zero_port() {
-        // Test that port 0 is rejected (ports are 1-indexed)
         let network1 = Network::new("files/ntwk1.s2p".to_string());
         let network2 = Network::new("files/ntwk2.s2p".to_string());
+        let _ = network1.cascade_ports(&network2, 0, 1);
+    }
 
-        // This should panic - ports are 1-indexed, not 0-indexed
-        network1.cascade_ports(&network2, 0, 1);
+    #[test]
+    fn test_save_load_roundtrip_ma_format() {
+        let network1 = Network::new("files/hfss_threeport_MA.s3p".to_string());
+        assert_eq!(network1.format, "MA");
+
+        let temp_dir = std::env::temp_dir()
+            .join("touchstone_tests")
+            .join("roundtrip_ma");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let file_path = temp_dir.join("roundtrip_ma.s3p");
+        let file_path_str = file_path.to_str().unwrap();
+
+        network1.save(file_path_str).unwrap();
+        let network2 = Network::new(file_path_str.to_string());
+
+        assert_eq!(network1.rank, network2.rank);
+        assert_eq!(network1.format, network2.format);
+        assert_eq!(network1.f.len(), network2.f.len());
+
+        let epsilon = 1e-6;
+        for i in 0..network1.s.len() {
+            for row in 1..=3 {
+                for col in 1..=3 {
+                    let s1 = &network1.s[i].s_ma;
+                    let s2 = &network2.s[i].s_ma;
+                    assert!(
+                        (s1.get(row, col).0 - s2.get(row, col).0).abs() < epsilon,
+                        "S{}{} mag mismatch at index {}",
+                        row, col, i
+                    );
+                    assert!(
+                        (s1.get(row, col).1 - s2.get(row, col).1).abs() < epsilon,
+                        "S{}{} angle mismatch at index {}",
+                        row, col, i
+                    );
+                }
+            }
+        }
+
+        std::fs::remove_file(file_path).unwrap();
+    }
+
+    #[test]
+    fn test_save_load_roundtrip_db_format() {
+        let network1 = Network::new("files/hfss_threeport_DB.s3p".to_string());
+        assert_eq!(network1.format, "DB");
+
+        let temp_dir = std::env::temp_dir()
+            .join("touchstone_tests")
+            .join("roundtrip_db");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let file_path = temp_dir.join("roundtrip_db.s3p");
+        let file_path_str = file_path.to_str().unwrap();
+
+        network1.save(file_path_str).unwrap();
+        let network2 = Network::new(file_path_str.to_string());
+
+        assert_eq!(network1.rank, network2.rank);
+        assert_eq!(network1.format, network2.format);
+        assert_eq!(network1.f.len(), network2.f.len());
+
+        let epsilon = 1e-6;
+        for i in 0..network1.s.len() {
+            for row in 1..=3 {
+                for col in 1..=3 {
+                    let s1 = &network1.s[i].s_db;
+                    let s2 = &network2.s[i].s_db;
+                    assert!(
+                        (s1.get(row, col).0 - s2.get(row, col).0).abs() < epsilon,
+                        "S{}{} dB mismatch at index {}",
+                        row, col, i
+                    );
+                    assert!(
+                        (s1.get(row, col).1 - s2.get(row, col).1).abs() < epsilon,
+                        "S{}{} angle mismatch at index {}",
+                        row, col, i
+                    );
+                }
+            }
+        }
+
+        std::fs::remove_file(file_path).unwrap();
+    }
+
+    #[test]
+    fn test_save_load_roundtrip_1port() {
+        let network1 = Network::new("files/hfss_oneport.s1p".to_string());
+
+        let temp_dir = std::env::temp_dir()
+            .join("touchstone_tests")
+            .join("roundtrip_1port");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let file_path = temp_dir.join("roundtrip.s1p");
+        let file_path_str = file_path.to_str().unwrap();
+
+        network1.save(file_path_str).unwrap();
+        let network2 = Network::new(file_path_str.to_string());
+
+        assert_eq!(network1.rank, 1);
+        assert_eq!(network1.rank, network2.rank);
+        assert_eq!(network1.f.len(), network2.f.len());
+
+        let epsilon = 1e-6;
+        for i in 0..network1.s.len() {
+            let s1 = &network1.s[i].s_ri;
+            let s2 = &network2.s[i].s_ri;
+            assert!((s1.get(1, 1).0 - s2.get(1, 1).0).abs() < epsilon);
+            assert!((s1.get(1, 1).1 - s2.get(1, 1).1).abs() < epsilon);
+        }
+
+        std::fs::remove_file(file_path).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot cascade networks with different reference impedances")]
+    fn test_cascade_different_z0() {
+        let mut net1 = Network::new("files/ntwk1.s2p".to_string());
+        let net2 = Network::new("files/ntwk2.s2p".to_string());
+        net1.z0 = 75.0;
+        let _ = net1.cascade(&net2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot cascade networks with different frequency units")]
+    fn test_cascade_different_freq_units() {
+        let mut net1 = Network::new("files/ntwk1.s2p".to_string());
+        let net2 = Network::new("files/ntwk2.s2p".to_string());
+        net1.frequency_unit = "MHz".to_string();
+        let _ = net1.cascade(&net2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cascading is only implemented for 2-port networks")]
+    fn test_cascade_non_2port() {
+        let net1 = Network::new("files/hfss_18.2.s3p".to_string());
+        let net2 = Network::new("files/hfss_18.2.s3p".to_string());
+        let _ = net1.cascade(&net2);
+    }
+
+    #[test]
+    fn test_print_summary() {
+        let net = Network::new("files/ntwk1.s2p".to_string());
+        // Just verify it doesn't panic
+        net.print_summary();
+    }
+
+    #[test]
+    fn test_clone() {
+        let net1 = Network::new("files/ntwk1.s2p".to_string());
+        let net2 = net1.clone();
+        assert_eq!(net1.rank, net2.rank);
+        assert_eq!(net1.f.len(), net2.f.len());
+        assert_eq!(net1.z0, net2.z0);
+    }
+
+    #[test]
+    fn test_debug() {
+        let net = Network::new("files/ntwk1.s2p".to_string());
+        let debug_str = format!("{:?}", net);
+        assert!(debug_str.contains("Network"));
     }
 }

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -211,13 +211,13 @@ fn s_db_ri_ma_consistency() {
 #[test]
 #[should_panic]
 fn nonexistent_file_panics() {
-    Network::new("files/does_not_exist.s2p".to_string());
+    let _ = Network::new("files/does_not_exist.s2p".to_string());
 }
 
 #[test]
 #[should_panic]
 fn invalid_extension_panics() {
-    Network::new("files/ntwk1.txt".to_string());
+    let _ = Network::new("files/ntwk1.txt".to_string());
 }
 
 // ============================================================


### PR DESCRIPTION
- Fix `#[must_use]` warnings in `should_panic` tests
- Add save/load roundtrip tests for MA and DB formats (3-port)
- Add 1-port save roundtrip test
- Add cascade error path tests (different z0, different freq units, non-2-port)
- Add print_summary, clone, Debug trait coverage
- **175 tests** (was 166), clippy clean