### PR TITLE
Make Network parsing fallible and add in-memory APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "touchstone"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "rfconversions",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/iancleary/touchstone"
 license = "MIT"
 name = "touchstone"
 repository = "https://github.com/iancleary/touchstone"
-version = "0.12.2"
+version = "0.13.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ println!("Data points: {}", ntwk.f.len());
 
 `Network::new` auto-detects the port count, data format, and frequency unit from the file.
 
+Use `Network::try_new` when you want I/O and parse errors instead of panics:
+
+```rust
+use touchstone::Network;
+
+fn main() -> Result<(), touchstone::TouchstoneError> {
+    let ntwk = Network::try_new("files/ntwk1.s2p")?;
+    println!("Ports: {}", ntwk.rank);
+    Ok(())
+}
+```
+
+For uploaded data or API endpoints, parse Touchstone content directly from memory. The
+`source_name` argument is used as the network name and for `.sNp` extension inference:
+
+```rust
+use touchstone::Network;
+
+fn main() -> Result<(), touchstone::TouchstoneError> {
+    let body = b"# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n";
+    let ntwk = Network::from_bytes("uploaded.s2p", body)?;
+
+    assert_eq!(ntwk.rank, 2);
+    Ok(())
+}
+```
+
 ---
 
 ## 3. Accessing S-Parameters
@@ -280,6 +307,9 @@ If you use `touchstone` as a library, install any `tracing` subscriber in your a
 | Item                          | Description                                  |
 |-------------------------------|----------------------------------------------|
 | `Network::new(path)`          | Parse a Touchstone file into a `Network`     |
+| `Network::try_new(path)`      | Parse a Touchstone file and return errors    |
+| `Network::from_bytes(name, bytes)` | Parse in-memory UTF-8 Touchstone bytes  |
+| `Network::from_str(name, contents)` | Parse an in-memory Touchstone string    |
 | `network.rank`                | Number of ports                              |
 | `network.frequency_unit`      | Frequency unit string                        |
 | `network.format`              | Data format (`RI`, `MA`, or `DB`)            |

--- a/README.md
+++ b/README.md
@@ -46,28 +46,20 @@ Use `Network::new` to parse any Touchstone file:
 ```rust
 use touchstone::Network;
 
-let ntwk = Network::new("files/ntwk1.s2p".to_string());
-
-println!("Ports: {}", ntwk.rank);
-println!("Frequency unit: {}", ntwk.frequency_unit);
-println!("Format: {}", ntwk.format);
-println!("Reference impedance: {} Ω", ntwk.z0);
-println!("Data points: {}", ntwk.f.len());
-```
-
-`Network::new` auto-detects the port count, data format, and frequency unit from the file.
-
-Use `Network::try_new` when you want I/O and parse errors instead of panics:
-
-```rust
-use touchstone::Network;
-
 fn main() -> Result<(), touchstone::TouchstoneError> {
-    let ntwk = Network::try_new("files/ntwk1.s2p")?;
+    let ntwk = Network::new("files/ntwk1.s2p")?;
+
     println!("Ports: {}", ntwk.rank);
+    println!("Frequency unit: {}", ntwk.frequency_unit);
+    println!("Format: {}", ntwk.format);
+    println!("Reference impedance: {} Ω", ntwk.z0);
+    println!("Data points: {}", ntwk.f.len());
     Ok(())
 }
 ```
+
+`Network::new` auto-detects the port count, data format, and frequency unit from the file, and
+returns I/O or parse errors instead of panicking.
 
 For uploaded data or API endpoints, parse Touchstone content directly from memory. The
 `source_name` argument is used as the network name and for `.sNp` extension inference:
@@ -102,7 +94,7 @@ Three accessor methods return a `Vec` over all frequencies:
 ```rust
 use touchstone::Network;
 
-let ntwk = Network::new("files/ntwk1.s2p".to_string());
+let ntwk = Network::new("files/ntwk1.s2p")?;
 
 // S11 in dB (return loss)
 let s11_db = ntwk.s_db(1, 1);
@@ -151,7 +143,7 @@ multi-line format (3+ ports):
 ```rust
 use touchstone::Network;
 
-let ntwk = Network::new("files/ntwk1.s2p".to_string());
+let ntwk = Network::new("files/ntwk1.s2p")?;
 ntwk.save("output.s2p").unwrap();
 ```
 
@@ -165,8 +157,8 @@ The standard `cascade` connects port 2 of the first network to port 1 of the sec
 ```rust
 use touchstone::Network;
 
-let net1 = Network::new("files/ntwk1.s2p".to_string());
-let net2 = Network::new("files/ntwk2.s2p".to_string());
+let net1 = Network::new("files/ntwk1.s2p")?;
+let net2 = Network::new("files/ntwk2.s2p")?;
 
 let cascaded = net1.cascade(&net2);
 println!("Cascaded network has {} data points", cascaded.f.len());
@@ -177,8 +169,8 @@ For explicit port specification, use `cascade_ports`:
 ```rust
 use touchstone::Network;
 
-let net1 = Network::new("files/ntwk1.s2p".to_string());
-let net2 = Network::new("files/ntwk2.s2p".to_string());
+let net1 = Network::new("files/ntwk1.s2p")?;
+let net2 = Network::new("files/ntwk2.s2p")?;
 
 let cascaded = net1.cascade_ports(&net2, 2, 1);
 ```
@@ -306,8 +298,7 @@ If you use `touchstone` as a library, install any `tracing` subscriber in your a
 
 | Item                          | Description                                  |
 |-------------------------------|----------------------------------------------|
-| `Network::new(path)`          | Parse a Touchstone file into a `Network`     |
-| `Network::try_new(path)`      | Parse a Touchstone file and return errors    |
+| `Network::new(path)`          | Parse a Touchstone file and return errors    |
 | `Network::from_bytes(name, bytes)` | Parse in-memory UTF-8 Touchstone bytes  |
 | `Network::from_str(name, contents)` | Parse an in-memory Touchstone string    |
 | `network.rank`                | Number of ports                              |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,7 +63,11 @@ impl Config {
 
                 let mut networks = Vec::new();
                 for path in file_paths.iter() {
-                    networks.push(Network::new(path.clone()));
+                    let network = Network::new(path).map_err(|error| {
+                        tracing::error!("Failed to parse Touchstone file {}: {}", path, error);
+                        "Failed to parse Touchstone file"
+                    })?;
+                    networks.push(network);
                 }
 
                 let mut result = networks[0].clone();
@@ -124,7 +128,7 @@ impl Config {
         // touchstone arg[1], such as touchstone files/ntwk1.s2p
         let file_argument = args[1].clone();
 
-        parse_plot_open_in_browser(file_argument.clone());
+        parse_plot_open_in_browser(file_argument.clone())?;
 
         Ok(Config {})
     }
@@ -233,7 +237,7 @@ fn generate_plot(networks: &[Network], file_path_plot: String) {
     tracing::info!("Plot HTML generated at {}", file_path_plot);
 }
 
-fn parse_plot_open_in_browser(file_path: String) {
+fn parse_plot_open_in_browser(file_path: String) -> Result<(), &'static str> {
     let path = std::path::Path::new(&file_path);
     let mut networks = Vec::new();
 
@@ -251,7 +255,15 @@ fn parse_plot_open_in_browser(file_path: String) {
                         if ext_str.starts_with('s') && ext_str.ends_with('p') && ext_str.len() == 3
                         {
                             tracing::debug!("Found network file: {:?}", path);
-                            networks.push(Network::new(path.to_string_lossy().to_string()));
+                            let network = Network::new(&path).map_err(|error| {
+                                tracing::error!(
+                                    "Failed to parse Touchstone file {}: {}",
+                                    path.display(),
+                                    error
+                                );
+                                "Failed to parse Touchstone file"
+                            })?;
+                            networks.push(network);
                         }
                     }
                 }
@@ -271,7 +283,10 @@ fn parse_plot_open_in_browser(file_path: String) {
         // Single file
         tracing::info!("Single file detected: {}", file_path);
 
-        let s2p = Network::new(file_path.clone());
+        let s2p = Network::new(&file_path).map_err(|error| {
+            tracing::error!("Failed to parse Touchstone file {}: {}", file_path, error);
+            "Failed to parse Touchstone file"
+        })?;
         networks.push(s2p);
 
         let file_path_config: file_operations::FilePathConfig =
@@ -303,6 +318,8 @@ fn parse_plot_open_in_browser(file_path: String) {
         generate_plot(&networks, output_html_path.clone());
         open::plot(output_html_path.clone());
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -399,7 +416,7 @@ mod tests {
         )
         .unwrap();
 
-        parse_plot_open_in_browser(s2p_path_rel.to_str().unwrap().to_string());
+        parse_plot_open_in_browser(s2p_path_rel.to_str().unwrap().to_string()).unwrap();
         // Output should be next to it
         assert!(s2p_path_rel.with_extension("s2p.html").exists());
         assert!(test_dir_rel.join("js").exists());
@@ -417,7 +434,7 @@ mod tests {
             "test_cli_run_bare_filename.s2p",
         );
         let bare_filename = String::from("test_cli_run_bare_filename.s2p");
-        parse_plot_open_in_browser(bare_filename);
+        parse_plot_open_in_browser(bare_filename).unwrap();
         let _bare_filename_remove_file_s2p = fs::remove_file("test_cli_run_bare_filename.s2p");
         let _bare_filename_remove_file_html =
             fs::remove_file("test_cli_run_bare_filename.s2p.html");
@@ -435,7 +452,7 @@ mod tests {
         let path_buf = std::fs::canonicalize(&s2p_path_abs).unwrap();
         let absolute_path: String = path_buf.to_string_lossy().to_string();
 
-        parse_plot_open_in_browser(absolute_path);
+        parse_plot_open_in_browser(absolute_path).unwrap();
 
         assert!(s2p_path_abs.with_extension("s2p.html").exists());
         assert!(test_dir_abs.join("js").exists());
@@ -531,7 +548,7 @@ mod tests {
         fs::write(&txt_file, "ignore me").unwrap();
 
         // Pass the directory path
-        parse_plot_open_in_browser(test_dir.to_str().unwrap().to_string());
+        parse_plot_open_in_browser(test_dir.to_str().unwrap().to_string()).unwrap();
 
         // Check for combined output
         let expected_output = test_dir.join("combined_plot.html");

--- a/src/data_line.rs
+++ b/src/data_line.rs
@@ -1,4 +1,5 @@
-use crate::utils::str_to_f64;
+use crate::utils::try_str_to_f64;
+use crate::TouchstoneError;
 
 use crate::data_pairs::DecibelAngle;
 use crate::data_pairs::DecibelAngleMatrix;
@@ -23,11 +24,13 @@ pub(crate) enum TwoPortDataOrder {
 }
 
 impl TwoPortDataOrder {
-    pub(crate) fn from_keyword_argument(argument: &str) -> Self {
+    pub(crate) fn try_from_keyword_argument(argument: &str) -> Result<Self, TouchstoneError> {
         match argument.trim().to_ascii_lowercase().as_str() {
-            "21_12" => Self::N21N12,
-            "12_21" => Self::N12N21,
-            _ => panic!("Unsupported [Two-Port Data Order]: {}", argument),
+            "21_12" => Ok(Self::N21N12),
+            "12_21" => Ok(Self::N12N21),
+            _ => Err(TouchstoneError::UnsupportedTwoPortDataOrder {
+                order: argument.to_string(),
+            }),
         }
     }
 }
@@ -48,6 +51,7 @@ pub(crate) fn parse_data_line(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn parse_data_line_with_order(
     data_lines: Vec<String>,
     format: &String,
@@ -55,6 +59,17 @@ pub(crate) fn parse_data_line_with_order(
     frequency_unit: &String,
     two_port_order: TwoPortDataOrder,
 ) -> ParsedDataLine {
+    try_parse_data_line_with_order(data_lines, format, n, frequency_unit, two_port_order)
+        .expect("failed to parse data line")
+}
+
+pub(crate) fn try_parse_data_line_with_order(
+    data_lines: Vec<String>,
+    format: &String,
+    n: &i32,
+    frequency_unit: &String,
+    two_port_order: TwoPortDataOrder,
+) -> Result<ParsedDataLine, TouchstoneError> {
     // println!("\n");
     // println!("format:\n{:?}", *format);
     // println!("n (number of ports): {:?}", *n);
@@ -94,21 +109,25 @@ pub(crate) fn parse_data_line_with_order(
     // println!("Data Line Parts (len {}): {:?}", len_parts, parts);
 
     if len_parts != expect_number_of_parts as usize {
-        panic!(
-            "Data line has unexpected number of parts. Expected {}, got {}",
-            expect_number_of_parts, len_parts
-        );
+        return Err(TouchstoneError::InvalidDataLineParts {
+            expected: expect_number_of_parts as usize,
+            actual: len_parts,
+        });
     }
 
     // split into f64 parts, after checking the expected length
-    let f64_parts: Vec<_> = parts.clone().into_iter().map(str_to_f64).collect();
+    let f64_parts: Vec<_> = parts
+        .clone()
+        .into_iter()
+        .map(try_str_to_f64)
+        .collect::<Result<_, _>>()?;
 
     // println!("{}", len_parts);
     // println!("f64_parts (len {}): {:?}", len_parts, f64_parts);
 
     let n_usize = *n as usize;
 
-    let mut frequency = str_to_f64(parts[0]);
+    let mut frequency = f64_parts[0];
 
     if frequency_unit == "THz" {
         // convert to Hz
@@ -138,7 +157,9 @@ pub(crate) fn parse_data_line_with_order(
         // no conversion needed
         // println!("Frequency is already in Hz: {} Hz", frequency);
     } else {
-        panic!("Unsupported frequency unit: {}", frequency_unit);
+        return Err(TouchstoneError::UnsupportedFrequencyUnit {
+            unit: frequency_unit.clone(),
+        });
     }
 
     if format == "RI" {
@@ -173,12 +194,12 @@ pub(crate) fn parse_data_line_with_order(
         }
         let s_ma = MagnitudeAngleMatrix::from_vec(s_ma_data);
 
-        ParsedDataLine {
+        Ok(ParsedDataLine {
             frequency,
             s_ri,
             s_db,
             s_ma,
-        }
+        })
     } else if format == "MA" {
         // Magnitude-Angle format
         let pairs = parse_pairs(&f64_parts, n_usize, MagnitudeAngle);
@@ -211,12 +232,12 @@ pub(crate) fn parse_data_line_with_order(
         }
         let s_db = DecibelAngleMatrix::from_vec(s_db_data);
 
-        ParsedDataLine {
+        Ok(ParsedDataLine {
             frequency,
             s_ri,
             s_db,
             s_ma,
-        }
+        })
     } else if format == "DB" {
         // Decibel-Angle format
         let pairs = parse_pairs(&f64_parts, n_usize, DecibelAngle);
@@ -249,14 +270,16 @@ pub(crate) fn parse_data_line_with_order(
         }
         let s_ma = MagnitudeAngleMatrix::from_vec(s_ma_data);
 
-        ParsedDataLine {
+        Ok(ParsedDataLine {
             frequency,
             s_ri,
             s_db,
             s_ma,
-        }
+        })
     } else {
-        panic!("Unsupported format: {}", format);
+        Err(TouchstoneError::UnsupportedFormat {
+            format: format.clone(),
+        })
     }
 }
 
@@ -459,25 +482,60 @@ mod tests {
         assert!(approx_eq(db.0, 20.0 * mag.log10(), 1e-6));
     }
 
-    // --- Panics ---
     #[test]
-    #[should_panic(expected = "Unsupported format")]
-    fn test_parse_unsupported_format_panics() {
+    fn test_parse_unsupported_format_returns_error() {
         let lines = vec!["1e9 0.1 0.2".to_string()];
-        parse_data_line(lines, &"XX".to_string(), &1, &"Hz".to_string());
+        let error = try_parse_data_line_with_order(
+            lines,
+            &"XX".to_string(),
+            &1,
+            &"Hz".to_string(),
+            TwoPortDataOrder::default(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TouchstoneError::UnsupportedFormat { format } if format == "XX"
+        ));
     }
 
     #[test]
-    #[should_panic(expected = "Unsupported frequency unit")]
-    fn test_parse_unsupported_frequency_unit_panics() {
+    fn test_parse_unsupported_frequency_unit_returns_error() {
         let lines = vec!["1e9 0.1 0.2".to_string()];
-        parse_data_line(lines, &"RI".to_string(), &1, &"PHz".to_string());
+        let error = try_parse_data_line_with_order(
+            lines,
+            &"RI".to_string(),
+            &1,
+            &"PHz".to_string(),
+            TwoPortDataOrder::default(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TouchstoneError::UnsupportedFrequencyUnit { unit } if unit == "PHz"
+        ));
     }
 
     #[test]
-    #[should_panic(expected = "unexpected number of parts")]
-    fn test_parse_wrong_number_of_parts_panics() {
+    fn test_parse_wrong_number_of_parts_returns_error() {
         let lines = vec!["1e9 0.1".to_string()]; // Missing second value for 1-port
-        parse_data_line(lines, &"RI".to_string(), &1, &"Hz".to_string());
+        let error = try_parse_data_line_with_order(
+            lines,
+            &"RI".to_string(),
+            &1,
+            &"Hz".to_string(),
+            TwoPortDataOrder::default(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TouchstoneError::InvalidDataLineParts {
+                expected: 3,
+                actual: 2
+            }
+        ));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,175 @@
+use std::fmt;
+
+/// Error returned when Touchstone data cannot be read or parsed.
+#[derive(Debug)]
+pub enum TouchstoneError {
+    /// The source file could not be read.
+    Io(std::io::Error),
+    /// In-memory bytes were not valid UTF-8 Touchstone text.
+    InvalidUtf8(std::str::Utf8Error),
+    /// The source name did not include a file extension.
+    MissingFileType {
+        /// Source name used for extension inference.
+        source_name: String,
+    },
+    /// The source extension is not a supported Touchstone file type.
+    UnsupportedFileType {
+        /// Unsupported extension without the leading dot.
+        file_type: String,
+    },
+    /// The Touchstone extension did not contain a valid port count.
+    InvalidPortCount {
+        /// Extension that could not be converted to a port count.
+        file_type: String,
+    },
+    /// The file contained more than one option line.
+    MultipleOptionLines,
+    /// A data line did not contain the expected number of values.
+    InvalidDataLineParts {
+        /// Number of values required for the current network rank.
+        expected: usize,
+        /// Number of values found in the line.
+        actual: usize,
+    },
+    /// A numeric token could not be parsed as `f64`.
+    InvalidNumber {
+        /// Token that failed numeric parsing.
+        token: String,
+    },
+    /// The frequency unit is not supported.
+    UnsupportedFrequencyUnit {
+        /// Unit token from the option line.
+        unit: String,
+    },
+    /// The network data format is not supported.
+    UnsupportedFormat {
+        /// Format token from the option line.
+        format: String,
+    },
+    /// A keyword line was malformed.
+    InvalidKeywordLine {
+        /// Full keyword line.
+        line: String,
+    },
+    /// The Touchstone version is not supported.
+    UnsupportedVersion {
+        /// Version string from the `[Version]` keyword.
+        version: String,
+    },
+    /// The `[Number of Ports]` value was not a valid integer.
+    InvalidNumberOfPorts {
+        /// Raw value from the keyword.
+        value: String,
+    },
+    /// The `[Number of Ports]` value did not match the source extension.
+    NumberOfPortsMismatch {
+        /// Port count declared by the keyword.
+        keyword_ports: i32,
+        /// Port count inferred from the source extension.
+        extension_ports: i32,
+    },
+    /// `[Two-Port Data Order]` was present for a network other than `.s2p`.
+    TwoPortDataOrderForNonTwoPort,
+    /// The `[Two-Port Data Order]` value is not supported.
+    UnsupportedTwoPortDataOrder {
+        /// Order token from the keyword.
+        order: String,
+    },
+    /// The `[Number of Frequencies]` value was not a valid integer.
+    InvalidNumberOfFrequencies {
+        /// Raw value from the keyword.
+        value: String,
+    },
+    /// The parsed data line count did not match `[Number of Frequencies]`.
+    NumberOfFrequenciesMismatch {
+        /// Expected number of frequency rows.
+        expected: usize,
+        /// Parsed number of frequency rows.
+        actual: usize,
+    },
+    /// Matrix format values other than `Full` are not supported.
+    UnsupportedMatrixFormat {
+        /// Matrix format token from the keyword.
+        format: String,
+    },
+}
+
+impl fmt::Display for TouchstoneError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "failed to read Touchstone file: {err}"),
+            Self::InvalidUtf8(err) => write!(f, "Touchstone data is not valid UTF-8: {err}"),
+            Self::MissingFileType { source_name } => {
+                write!(f, "Touchstone source name has no file extension: {source_name}")
+            }
+            Self::UnsupportedFileType { file_type } => {
+                write!(f, "unsupported Touchstone file type: {file_type}")
+            }
+            Self::InvalidPortCount { file_type } => {
+                write!(f, "invalid port count in Touchstone file type: {file_type}")
+            }
+            Self::MultipleOptionLines => write!(f, "multiple option lines found"),
+            Self::InvalidDataLineParts { expected, actual } => write!(
+                f,
+                "invalid data line: expected {expected} values, found {actual}"
+            ),
+            Self::InvalidNumber { token } => write!(f, "invalid numeric token: {token}"),
+            Self::UnsupportedFrequencyUnit { unit } => {
+                write!(f, "unsupported frequency unit: {unit}")
+            }
+            Self::UnsupportedFormat { format } => write!(f, "unsupported data format: {format}"),
+            Self::InvalidKeywordLine { line } => write!(f, "invalid keyword line: {line}"),
+            Self::UnsupportedVersion { version } => {
+                write!(f, "unsupported Touchstone version: {version}")
+            }
+            Self::InvalidNumberOfPorts { value } => {
+                write!(f, "invalid [Number of Ports] value: {value}")
+            }
+            Self::NumberOfPortsMismatch {
+                keyword_ports,
+                extension_ports,
+            } => write!(
+                f,
+                "[Number of Ports] value {keyword_ports} does not match extension port count {extension_ports}"
+            ),
+            Self::TwoPortDataOrderForNonTwoPort => {
+                write!(f, "[Two-Port Data Order] is only valid for two-port networks")
+            }
+            Self::UnsupportedTwoPortDataOrder { order } => {
+                write!(f, "unsupported [Two-Port Data Order] value: {order}")
+            }
+            Self::InvalidNumberOfFrequencies { value } => {
+                write!(f, "invalid [Number of Frequencies] value: {value}")
+            }
+            Self::NumberOfFrequenciesMismatch { expected, actual } => write!(
+                f,
+                "[Number of Frequencies] value {expected} does not match parsed data rows {actual}"
+            ),
+            Self::UnsupportedMatrixFormat { format } => {
+                write!(f, "unsupported [Matrix Format] value: {format}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TouchstoneError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            Self::InvalidUtf8(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for TouchstoneError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl From<std::str::Utf8Error> for TouchstoneError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Self::InvalidUtf8(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ```
 //! use touchstone::Network;
 //!
-//! let net = Network::new("files/ntwk1.s2p".to_string());
+//! let net = Network::new("files/ntwk1.s2p").unwrap();
 //! assert_eq!(net.rank, 2);
 //! ```
 
@@ -38,7 +38,7 @@ pub use error::TouchstoneError;
 /// ```
 /// use touchstone::Network;
 ///
-/// let net = Network::new("files/ntwk1.s2p".to_string());
+/// let net = Network::new("files/ntwk1.s2p").unwrap();
 /// assert_eq!(net.rank, 2);
 /// println!("Loaded {} frequency points", net.f.len());
 /// ```
@@ -81,7 +81,7 @@ pub struct Network {
 /// ```
 /// use touchstone::Network;
 ///
-/// let net = Network::new("files/ntwk1.s2p".to_string());
+/// let net = Network::new("files/ntwk1.s2p").unwrap();
 /// let s11_ri = net.s_ri(1, 1);
 /// let point = &s11_ri[0];
 /// println!("f = {} Hz, S11 = ({}, {})", point.frequency, point.s_ri.0, point.s_ri.1);
@@ -101,7 +101,7 @@ pub struct FrequencyRI {
 /// ```
 /// use touchstone::Network;
 ///
-/// let net = Network::new("files/ntwk1.s2p".to_string());
+/// let net = Network::new("files/ntwk1.s2p").unwrap();
 /// let s21_db = net.s_db(2, 1);
 /// let point = &s21_db[0];
 /// println!("f = {} Hz, S21 = {} dB ∠ {}°", point.frequency, point.s_db.0, point.s_db.1);
@@ -121,7 +121,7 @@ pub struct FrequencyDB {
 /// ```
 /// use touchstone::Network;
 ///
-/// let net = Network::new("files/ntwk1.s2p".to_string());
+/// let net = Network::new("files/ntwk1.s2p").unwrap();
 /// let s11_ma = net.s_ma(1, 1);
 /// let point = &s11_ma[0];
 /// println!("f = {} Hz, S11 = {} ∠ {}°", point.frequency, point.s_ma.0, point.s_ma.1);
@@ -142,25 +142,12 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net = Network::new("files/ntwk1.s2p".to_string());
+    /// let net = Network::new("files/ntwk1.s2p")?;
     /// assert_eq!(net.rank, 2);
     /// assert!(!net.f.is_empty());
-    /// ```
-    #[must_use]
-    pub fn new(file_path: String) -> Self {
-        Self::try_new(file_path).expect("failed to parse Touchstone file")
-    }
-
-    /// Creates a Network from a file path, returning parse and I/O errors.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let network = touchstone::Network::try_new("files/ntwk1.s2p")?;
-    /// assert_eq!(network.rank, 2);
     /// # Ok::<(), touchstone::TouchstoneError>(())
     /// ```
-    pub fn try_new<P: AsRef<std::path::Path>>(file_path: P) -> Result<Self, TouchstoneError> {
+    pub fn new<P: AsRef<std::path::Path>>(file_path: P) -> Result<Self, TouchstoneError> {
         parser::try_read_file(file_path)
     }
 
@@ -212,7 +199,7 @@ impl Network {
     /// ```no_run
     /// use touchstone::Network;
     ///
-    /// let net = Network::new("files/ntwk1.s2p".to_string());
+    /// let net = Network::new("files/ntwk1.s2p").unwrap();
     /// net.print_summary();
     /// ```
     pub fn print_summary(&self) {
@@ -237,7 +224,7 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net = Network::new("files/ntwk1.s2p".to_string());
+    /// let net = Network::new("files/ntwk1.s2p").unwrap();
     /// let freqs = net.f();
     /// assert_eq!(freqs.len(), net.f.len());
     /// ```
@@ -255,7 +242,7 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net = Network::new("files/ntwk1.s2p".to_string());
+    /// let net = Network::new("files/ntwk1.s2p").unwrap();
     /// let s21 = net.s_db(2, 1);
     /// assert_eq!(s21.len(), net.f.len());
     /// println!("S21 at first freq: {} dB", s21[0].s_db.0);
@@ -288,7 +275,7 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net = Network::new("files/ntwk1.s2p".to_string());
+    /// let net = Network::new("files/ntwk1.s2p").unwrap();
     /// let s11 = net.s_ri(1, 1);
     /// assert_eq!(s11.len(), net.f.len());
     /// println!("S11 at first freq: {} + j{}", s11[0].s_ri.0, s11[0].s_ri.1);
@@ -318,7 +305,7 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net = Network::new("files/ntwk1.s2p".to_string());
+    /// let net = Network::new("files/ntwk1.s2p").unwrap();
     /// let s11 = net.s_ma(1, 1);
     /// assert_eq!(s11.len(), net.f.len());
     /// println!("S11 at first freq: {} ∠ {}°", s11[0].s_ma.0, s11[0].s_ma.1);
@@ -348,8 +335,8 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net1 = Network::new("files/ntwk1.s2p".to_string());
-    /// let net2 = Network::new("files/ntwk2.s2p".to_string());
+    /// let net1 = Network::new("files/ntwk1.s2p").unwrap();
+    /// let net2 = Network::new("files/ntwk2.s2p").unwrap();
     /// let cascaded = net1.cascade(&net2);
     /// assert_eq!(cascaded.rank, 2);
     /// ```
@@ -487,8 +474,8 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net1 = Network::new("files/ntwk1.s2p".to_string());
-    /// let net2 = Network::new("files/ntwk2.s2p".to_string());
+    /// let net1 = Network::new("files/ntwk1.s2p").unwrap();
+    /// let net2 = Network::new("files/ntwk2.s2p").unwrap();
     ///
     /// // Standard 2-port cascade (port 2 → port 1)
     /// let result = net1.cascade_ports(&net2, 2, 1);
@@ -559,7 +546,7 @@ impl Network {
     /// ```
     /// use touchstone::Network;
     ///
-    /// let net = Network::new("files/ntwk1.s2p".to_string());
+    /// let net = Network::new("files/ntwk1.s2p").unwrap();
     /// let tmp = std::env::temp_dir().join("example_output.s2p");
     /// net.save(tmp.to_str().unwrap()).unwrap();
     /// std::fs::remove_file(tmp).unwrap();
@@ -770,7 +757,7 @@ mod tests {
 
     #[test]
     fn f() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
         let f = network1.f();
 
         assert_eq!(f.len(), network1.f.len());
@@ -778,7 +765,7 @@ mod tests {
 
     #[test]
     fn s_db() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
 
         let s11 = network1.s_db(1, 1);
         let s12 = network1.s_db(1, 2);
@@ -792,7 +779,7 @@ mod tests {
 
     #[test]
     fn s_ri() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
 
         let s11 = network1.s_ri(1, 1);
         let s12 = network1.s_ri(1, 2);
@@ -806,7 +793,7 @@ mod tests {
 
     #[test]
     fn s_ma() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
 
         let s11 = network1.s_ma(1, 1);
         let s12 = network1.s_ma(1, 2);
@@ -820,10 +807,10 @@ mod tests {
 
     #[test]
     fn cascade_2port_networks() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
-        let network2 = Network::new("files/ntwk2.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
+        let network2 = Network::new("files/ntwk2.s2p").unwrap();
 
-        let network3 = Network::new("files/ntwk3.s2p".to_string());
+        let network3 = Network::new("files/ntwk3.s2p").unwrap();
 
         let cascaded_network = network1.cascade(&network2);
 
@@ -879,12 +866,12 @@ mod tests {
 
     #[test]
     fn cascade_2port_networks_operator() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
-        let network2 = Network::new("files/ntwk2.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
+        let network2 = Network::new("files/ntwk2.s2p").unwrap();
 
         let cascaded_network = network1 * network2;
 
-        let network3 = Network::new("files/ntwk3.s2p".to_string());
+        let network3 = Network::new("files/ntwk3.s2p").unwrap();
 
         assert_eq!(cascaded_network.f.len(), 91);
         assert_eq!(cascaded_network.s.len(), 91);
@@ -943,7 +930,7 @@ mod tests {
 
     #[test]
     fn test_save_load_roundtrip() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
 
         let temp_dir = std::env::temp_dir()
             .join("touchstone_tests")
@@ -954,7 +941,7 @@ mod tests {
 
         network1.save(file_path_str).unwrap();
 
-        let network2 = Network::new(file_path_str.to_string());
+        let network2 = Network::new(file_path_str).unwrap();
 
         assert_eq!(network1.f.len(), network2.f.len());
         assert_eq!(network1.s.len(), network2.s.len());
@@ -1005,7 +992,7 @@ mod tests {
         )
         .unwrap();
 
-        let network = Network::new(input_path.to_str().unwrap().to_string());
+        let network = Network::new(input_path.to_str().unwrap()).unwrap();
         assert_eq!(
             network.s_ri(2, 1)[0].s_ri,
             data_pairs::RealImaginary(4.0, 0.0)
@@ -1035,7 +1022,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(values, vec![1.0, 0.1, 0.0, 4.0, 0.0, 0.01, 0.0, 0.2, 0.0]);
 
-        let reloaded = Network::new(output_path.to_str().unwrap().to_string());
+        let reloaded = Network::new(output_path.to_str().unwrap()).unwrap();
         assert_eq!(
             reloaded.s_ri(2, 1)[0].s_ri,
             data_pairs::RealImaginary(4.0, 0.0)
@@ -1051,7 +1038,7 @@ mod tests {
 
     #[test]
     fn test_save_load_roundtrip_3port() {
-        let network1 = Network::new("files/hfss_18.2.s3p".to_string());
+        let network1 = Network::new("files/hfss_18.2.s3p").unwrap();
 
         let temp_dir = std::env::temp_dir()
             .join("touchstone_tests")
@@ -1062,7 +1049,7 @@ mod tests {
 
         network1.save(file_path_str).unwrap();
 
-        let network2 = Network::new(file_path_str.to_string());
+        let network2 = Network::new(file_path_str).unwrap();
 
         // Verify metadata
         assert_eq!(network1.rank, network2.rank);
@@ -1108,7 +1095,7 @@ mod tests {
 
     #[test]
     fn test_save_load_roundtrip_4port() {
-        let network1 = Network::new("files/Agilent_E5071B.s4p".to_string());
+        let network1 = Network::new("files/Agilent_E5071B.s4p").unwrap();
 
         let temp_dir = std::env::temp_dir()
             .join("touchstone_tests")
@@ -1119,7 +1106,7 @@ mod tests {
 
         network1.save(file_path_str).unwrap();
 
-        let network2 = Network::new(file_path_str.to_string());
+        let network2 = Network::new(file_path_str).unwrap();
 
         // Verify metadata
         assert_eq!(network1.rank, network2.rank);
@@ -1166,9 +1153,9 @@ mod tests {
     #[test]
     fn test_cascade_ports_2port_standard() {
         // Test cascade_ports with standard 2-port connection (2→1)
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
-        let network2 = Network::new("files/ntwk2.s2p".to_string());
-        let network3 = Network::new("files/ntwk3.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
+        let network2 = Network::new("files/ntwk2.s2p").unwrap();
+        let network3 = Network::new("files/ntwk3.s2p").unwrap();
 
         // cascade_ports(2, 1) should give same result as cascade()
         let result_ports = network1.cascade_ports(&network2, 2, 1);
@@ -1193,8 +1180,8 @@ mod tests {
     #[should_panic(expected = "only standard cascade (port 2 → port 1) is currently supported")]
     fn test_cascade_ports_2port_nonstandard() {
         // Test that non-standard port connections panic with helpful message
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
-        let network2 = Network::new("files/ntwk2.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
+        let network2 = Network::new("files/ntwk2.s2p").unwrap();
 
         // This should panic because we don't support 1→2 connection yet
         let _ = network1.cascade_ports(&network2, 1, 2);
@@ -1203,30 +1190,30 @@ mod tests {
     #[test]
     #[should_panic(expected = "from_port 3 out of range for 2-port network")]
     fn test_cascade_ports_invalid_from_port() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
-        let network2 = Network::new("files/ntwk2.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
+        let network2 = Network::new("files/ntwk2.s2p").unwrap();
         let _ = network1.cascade_ports(&network2, 3, 1);
     }
 
     #[test]
     #[should_panic(expected = "to_port 5 out of range for 2-port network")]
     fn test_cascade_ports_invalid_to_port() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
-        let network2 = Network::new("files/ntwk2.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
+        let network2 = Network::new("files/ntwk2.s2p").unwrap();
         let _ = network1.cascade_ports(&network2, 2, 5);
     }
 
     #[test]
     #[should_panic(expected = "from_port 0 out of range")]
     fn test_cascade_ports_zero_port() {
-        let network1 = Network::new("files/ntwk1.s2p".to_string());
-        let network2 = Network::new("files/ntwk2.s2p".to_string());
+        let network1 = Network::new("files/ntwk1.s2p").unwrap();
+        let network2 = Network::new("files/ntwk2.s2p").unwrap();
         let _ = network1.cascade_ports(&network2, 0, 1);
     }
 
     #[test]
     fn test_save_load_roundtrip_ma_format() {
-        let network1 = Network::new("files/hfss_threeport_MA.s3p".to_string());
+        let network1 = Network::new("files/hfss_threeport_MA.s3p").unwrap();
         assert_eq!(network1.format, "MA");
 
         let temp_dir = std::env::temp_dir()
@@ -1237,7 +1224,7 @@ mod tests {
         let file_path_str = file_path.to_str().unwrap();
 
         network1.save(file_path_str).unwrap();
-        let network2 = Network::new(file_path_str.to_string());
+        let network2 = Network::new(file_path_str).unwrap();
 
         assert_eq!(network1.rank, network2.rank);
         assert_eq!(network1.format, network2.format);
@@ -1272,7 +1259,7 @@ mod tests {
 
     #[test]
     fn test_save_load_roundtrip_db_format() {
-        let network1 = Network::new("files/hfss_threeport_DB.s3p".to_string());
+        let network1 = Network::new("files/hfss_threeport_DB.s3p").unwrap();
         assert_eq!(network1.format, "DB");
 
         let temp_dir = std::env::temp_dir()
@@ -1283,7 +1270,7 @@ mod tests {
         let file_path_str = file_path.to_str().unwrap();
 
         network1.save(file_path_str).unwrap();
-        let network2 = Network::new(file_path_str.to_string());
+        let network2 = Network::new(file_path_str).unwrap();
 
         assert_eq!(network1.rank, network2.rank);
         assert_eq!(network1.format, network2.format);
@@ -1318,7 +1305,7 @@ mod tests {
 
     #[test]
     fn test_save_load_roundtrip_1port() {
-        let network1 = Network::new("files/hfss_oneport.s1p".to_string());
+        let network1 = Network::new("files/hfss_oneport.s1p").unwrap();
 
         let temp_dir = std::env::temp_dir()
             .join("touchstone_tests")
@@ -1328,7 +1315,7 @@ mod tests {
         let file_path_str = file_path.to_str().unwrap();
 
         network1.save(file_path_str).unwrap();
-        let network2 = Network::new(file_path_str.to_string());
+        let network2 = Network::new(file_path_str).unwrap();
 
         assert_eq!(network1.rank, 1);
         assert_eq!(network1.rank, network2.rank);
@@ -1348,8 +1335,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot cascade networks with different reference impedances")]
     fn test_cascade_different_z0() {
-        let mut net1 = Network::new("files/ntwk1.s2p".to_string());
-        let net2 = Network::new("files/ntwk2.s2p".to_string());
+        let mut net1 = Network::new("files/ntwk1.s2p").unwrap();
+        let net2 = Network::new("files/ntwk2.s2p").unwrap();
         net1.z0 = 75.0;
         let _ = net1.cascade(&net2);
     }
@@ -1357,8 +1344,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot cascade networks with different frequency units")]
     fn test_cascade_different_freq_units() {
-        let mut net1 = Network::new("files/ntwk1.s2p".to_string());
-        let net2 = Network::new("files/ntwk2.s2p".to_string());
+        let mut net1 = Network::new("files/ntwk1.s2p").unwrap();
+        let net2 = Network::new("files/ntwk2.s2p").unwrap();
         net1.frequency_unit = "MHz".to_string();
         let _ = net1.cascade(&net2);
     }
@@ -1366,21 +1353,21 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cascading is only implemented for 2-port networks")]
     fn test_cascade_non_2port() {
-        let net1 = Network::new("files/hfss_18.2.s3p".to_string());
-        let net2 = Network::new("files/hfss_18.2.s3p".to_string());
+        let net1 = Network::new("files/hfss_18.2.s3p").unwrap();
+        let net2 = Network::new("files/hfss_18.2.s3p").unwrap();
         let _ = net1.cascade(&net2);
     }
 
     #[test]
     fn test_print_summary() {
-        let net = Network::new("files/ntwk1.s2p".to_string());
+        let net = Network::new("files/ntwk1.s2p").unwrap();
         // Just verify it doesn't panic
         net.print_summary();
     }
 
     #[test]
     fn test_clone() {
-        let net1 = Network::new("files/ntwk1.s2p".to_string());
+        let net1 = Network::new("files/ntwk1.s2p").unwrap();
         let net2 = net1.clone();
         assert_eq!(net1.rank, net2.rank);
         assert_eq!(net1.f.len(), net2.f.len());
@@ -1389,7 +1376,7 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        let net = Network::new("files/ntwk1.s2p".to_string());
+        let net = Network::new("files/ntwk1.s2p").unwrap();
         let debug_str = format!("{:?}", net);
         assert!(debug_str.contains("Network"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use std::ops;
 pub mod cli;
 mod data_line;
 mod data_pairs;
+mod error;
 mod file_extension;
 mod file_operations;
 mod open;
@@ -25,6 +26,8 @@ mod option_line;
 mod parser;
 mod plot;
 mod utils;
+
+pub use error::TouchstoneError;
 
 /// A network parsed from a Touchstone (`.sNp`) file.
 ///
@@ -145,7 +148,61 @@ impl Network {
     /// ```
     #[must_use]
     pub fn new(file_path: String) -> Self {
-        parser::read_file(file_path)
+        Self::try_new(file_path).expect("failed to parse Touchstone file")
+    }
+
+    /// Creates a Network from a file path, returning parse and I/O errors.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let network = touchstone::Network::try_new("files/ntwk1.s2p")?;
+    /// assert_eq!(network.rank, 2);
+    /// # Ok::<(), touchstone::TouchstoneError>(())
+    /// ```
+    pub fn try_new<P: AsRef<std::path::Path>>(file_path: P) -> Result<Self, TouchstoneError> {
+        parser::try_read_file(file_path)
+    }
+
+    /// Creates a Network from in-memory UTF-8 bytes.
+    ///
+    /// The `source_name` is used as the network name and for Touchstone extension inference,
+    /// such as `uploaded.s2p`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let data = b"# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n";
+    /// let network = touchstone::Network::from_bytes("uploaded.s2p", data)?;
+    /// assert_eq!(network.rank, 2);
+    /// # Ok::<(), touchstone::TouchstoneError>(())
+    /// ```
+    pub fn from_bytes<S: AsRef<str>>(
+        source_name: S,
+        bytes: &[u8],
+    ) -> Result<Self, TouchstoneError> {
+        parser::parse_bytes(source_name.as_ref(), bytes)
+    }
+
+    /// Creates a Network from an in-memory Touchstone string.
+    ///
+    /// The `source_name` is used as the network name and for Touchstone extension inference,
+    /// such as `uploaded.s2p`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let data = "# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n";
+    /// let network = touchstone::Network::from_str("uploaded.s2p", data)?;
+    /// assert_eq!(network.rank, 2);
+    /// # Ok::<(), touchstone::TouchstoneError>(())
+    /// ```
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str<S: AsRef<str>>(
+        source_name: S,
+        contents: &str,
+    ) -> Result<Self, TouchstoneError> {
+        parser::parse_str(source_name.as_ref(), contents)
     }
 
     /// Print a human-readable summary of the network to stdout.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,10 +1,11 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use crate::data_line;
 use crate::file_extension;
 use crate::option_line;
 use crate::utils;
 use crate::Network;
+use crate::TouchstoneError;
 
 #[derive(Debug)]
 struct ParserState {
@@ -14,28 +15,28 @@ struct ParserState {
     expected_number_of_frequencies: Option<usize>,
 }
 
+#[cfg(test)]
 pub fn read_file(file_path: String) -> Network {
-    tracing::debug!("Parsing touchstone file: {}", file_path);
-    let contents = fs::read_to_string(&file_path).expect("Should have been able to read the file");
+    try_read_file(file_path).expect("failed to parse Touchstone file")
+}
 
-    let file_type = file_path
-        .split(".")
-        .last()
-        .expect("Failed to get file type from file path");
+pub fn try_read_file<P: AsRef<Path>>(file_path: P) -> Result<Network, TouchstoneError> {
+    let file_path = file_path.as_ref();
+    tracing::debug!("Parsing touchstone file: {}", file_path.display());
+    let contents = fs::read_to_string(file_path)?;
+    parse_str(file_path.to_string_lossy().as_ref(), &contents)
+}
 
-    let file_type_is_valid = file_extension::is_valid_file_extension(file_type);
+pub fn parse_bytes(source_name: &str, bytes: &[u8]) -> Result<Network, TouchstoneError> {
+    let contents = std::str::from_utf8(bytes)?;
+    parse_str(source_name, contents)
+}
 
-    if !file_type_is_valid {
-        panic!(
-            "File type not supported: {}, only sNp supported, where n is an integer without leading zeros.",
-            file_type
-        );
-    }
+pub fn parse_str(source_name: &str, contents: &str) -> Result<Network, TouchstoneError> {
+    tracing::debug!("Parsing touchstone source: {}", source_name);
 
-    let n_ports_str = &file_type[1..file_type.len() - 1];
-    let n_ports = n_ports_str
-        .parse::<i32>()
-        .expect("Failed to parse number of ports from file type");
+    let file_type = infer_file_type(source_name)?;
+    let n_ports = parse_number_of_ports(file_type)?;
 
     let mut parsed_options = option_line::Options::default();
     // println!("default options:\n{:?}", parsed_options);
@@ -94,10 +95,10 @@ pub fn read_file(file_path: String) -> Network {
 
                 parser_state.option_line_parsed = true;
             } else {
-                panic!("Multiple option lines found in file. Only one option line is allowed.");
+                return Err(TouchstoneError::MultipleOptionLines);
             }
         } else if is_keyword {
-            if handle_keyword_line(trimmed_line, n_ports, &mut parser_state) {
+            if handle_keyword_line(trimmed_line, n_ports, &mut parser_state)? {
                 break;
             }
         } else if is_comment {
@@ -117,13 +118,13 @@ pub fn read_file(file_path: String) -> Network {
             // Check if we have collected enough values for a complete entry
             if current_value_count >= expected_values {
                 // Process this complete segment
-                let line_matrix_data = data_line::parse_data_line_with_order(
+                let line_matrix_data = data_line::try_parse_data_line_with_order(
                     current_data_segment.clone(),
                     &parsed_options.format,
                     &n_ports,
                     &parsed_options.frequency_unit,
                     parser_state.two_port_data_order,
-                );
+                )?;
 
                 f.push(line_matrix_data.frequency);
                 s.push(line_matrix_data);
@@ -139,13 +140,13 @@ pub fn read_file(file_path: String) -> Network {
 
     // Process the last data segment
     if !current_data_segment.is_empty() {
-        let line_matrix_data = data_line::parse_data_line_with_order(
+        let line_matrix_data = data_line::try_parse_data_line_with_order(
             current_data_segment.clone(),
             &parsed_options.format,
             &n_ports,
             &parsed_options.frequency_unit,
             parser_state.two_port_data_order,
-        );
+        )?;
 
         f.push(line_matrix_data.frequency);
         s.push(line_matrix_data);
@@ -155,11 +156,10 @@ pub fn read_file(file_path: String) -> Network {
 
     if let Some(expected_number_of_frequencies) = parser_state.expected_number_of_frequencies {
         if expected_number_of_frequencies != f.len() {
-            panic!(
-                "[Number of Frequencies] expected {} points, parsed {}",
-                expected_number_of_frequencies,
-                f.len()
-            );
+            return Err(TouchstoneError::NumberOfFrequenciesMismatch {
+                expected: expected_number_of_frequencies,
+                actual: f.len(),
+            });
         }
     }
 
@@ -171,70 +171,87 @@ pub fn read_file(file_path: String) -> Network {
         "Parsing complete"
     );
 
-    Network {
-        name: file_path,
+    Ok(Network {
+        name: source_name.to_string(),
         rank: n_ports,
         frequency_unit,
         parameter,
         format,
         resistance_string,
-        z0: utils::str_to_f64(reference_resistance.as_str()),
+        z0: utils::try_str_to_f64(reference_resistance.as_str())?,
         comments: comment_lines,
         comments_after_option_line,
         f,
         s,
-    }
+    })
 }
 
-fn handle_keyword_line(line: &str, n_ports: i32, parser_state: &mut ParserState) -> bool {
+fn handle_keyword_line(
+    line: &str,
+    n_ports: i32,
+    parser_state: &mut ParserState,
+) -> Result<bool, TouchstoneError> {
     let line_without_comment = line.split('!').next().unwrap_or("").trim();
-    let closing_bracket_index = line_without_comment
-        .find(']')
-        .unwrap_or_else(|| panic!("Invalid Touchstone keyword line: {}", line));
+    let closing_bracket_index =
+        line_without_comment
+            .find(']')
+            .ok_or_else(|| TouchstoneError::InvalidKeywordLine {
+                line: line.to_string(),
+            })?;
     let keyword = normalize_keyword(&line_without_comment[1..closing_bracket_index]);
     let argument = line_without_comment[closing_bracket_index + 1..].trim();
 
     match keyword.as_str() {
         "version" => match argument {
             "2.0" | "2.1" => {}
-            _ => panic!("Unsupported [Version]: {}", argument),
+            _ => {
+                return Err(TouchstoneError::UnsupportedVersion {
+                    version: argument.to_string(),
+                });
+            }
         },
         "number of ports" => {
-            let keyword_ports = argument
-                .parse::<i32>()
-                .unwrap_or_else(|_| panic!("Invalid [Number of Ports]: {}", argument));
+            let keyword_ports =
+                argument
+                    .parse::<i32>()
+                    .map_err(|_| TouchstoneError::InvalidNumberOfPorts {
+                        value: argument.to_string(),
+                    })?;
             if keyword_ports != n_ports {
-                panic!(
-                    "[Number of Ports] {} does not match file extension port count {}",
-                    keyword_ports, n_ports
-                );
+                return Err(TouchstoneError::NumberOfPortsMismatch {
+                    keyword_ports,
+                    extension_ports: n_ports,
+                });
             }
         }
         "two port data order" => {
             if n_ports != 2 {
-                panic!("[Two-Port Data Order] is only valid for 2-port files");
+                return Err(TouchstoneError::TwoPortDataOrderForNonTwoPort);
             }
             parser_state.two_port_data_order =
-                data_line::TwoPortDataOrder::from_keyword_argument(argument);
+                data_line::TwoPortDataOrder::try_from_keyword_argument(argument)?;
         }
         "number of frequencies" => {
-            parser_state.expected_number_of_frequencies = Some(
-                argument
-                    .parse::<usize>()
-                    .unwrap_or_else(|_| panic!("Invalid [Number of Frequencies]: {}", argument)),
-            );
+            parser_state.expected_number_of_frequencies =
+                Some(argument.parse::<usize>().map_err(|_| {
+                    TouchstoneError::InvalidNumberOfFrequencies {
+                        value: argument.to_string(),
+                    }
+                })?);
         }
         "network data" => {}
         "matrix format" => {
             if !argument.eq_ignore_ascii_case("Full") {
-                panic!("Only [Matrix Format] Full is currently supported");
+                return Err(TouchstoneError::UnsupportedMatrixFormat {
+                    format: argument.to_string(),
+                });
             }
         }
-        "end" => return true,
+        "end" => return Ok(true),
         _ => {}
     }
 
-    false
+    Ok(false)
 }
 
 fn normalize_keyword(keyword: &str) -> String {
@@ -244,6 +261,32 @@ fn normalize_keyword(keyword: &str) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn infer_file_type(source_name: &str) -> Result<&str, TouchstoneError> {
+    let file_type = source_name
+        .rsplit_once('.')
+        .map(|(_, file_type)| file_type)
+        .ok_or_else(|| TouchstoneError::MissingFileType {
+            source_name: source_name.to_string(),
+        })?;
+
+    if file_extension::is_valid_file_extension(file_type) {
+        Ok(file_type)
+    } else {
+        Err(TouchstoneError::UnsupportedFileType {
+            file_type: file_type.to_string(),
+        })
+    }
+}
+
+fn parse_number_of_ports(file_type: &str) -> Result<i32, TouchstoneError> {
+    let n_ports_str = &file_type[1..file_type.len() - 1];
+    n_ports_str
+        .parse::<i32>()
+        .map_err(|_| TouchstoneError::InvalidPortCount {
+            file_type: file_type.to_string(),
+        })
 }
 
 #[cfg(test)]

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -358,7 +358,7 @@ mod tests {
         let s1p_path = test_dir.join("test.s1p");
         fs::copy("files/hfss_oneport.s1p", &s1p_path).unwrap();
 
-        let network = Network::new(s1p_path.to_str().unwrap().to_string());
+        let network = Network::new(s1p_path.to_str().unwrap()).unwrap();
         let output_path = test_dir.join("oneport_plot.html");
         let output_str = output_path.to_str().unwrap().to_string();
 
@@ -406,8 +406,8 @@ mod tests {
 
     #[test]
     fn test_generate_plot_from_networks_rank_mismatch() {
-        let n1 = Network::new("files/hfss_oneport.s1p".to_string());
-        let n2 = Network::new("files/ntwk1.s2p".to_string());
+        let n1 = Network::new("files/hfss_oneport.s1p").unwrap();
+        let n2 = Network::new("files/ntwk1.s2p").unwrap();
         let test_dir = setup_test_dir("test_rank_mismatch");
         let output_path = test_dir.join("mismatch.html");
         let result = generate_plot_from_networks(&[n1, n2], output_path.to_str().unwrap());
@@ -419,7 +419,7 @@ mod tests {
 
     #[test]
     fn test_generate_plot_from_networks_one_port() {
-        let network = Network::new("files/hfss_oneport.s1p".to_string());
+        let network = Network::new("files/hfss_oneport.s1p").unwrap();
         let test_dir = setup_test_dir("test_plot_one_port");
         let output_path = test_dir.join("oneport.html");
         generate_plot_from_networks(&[network], output_path.to_str().unwrap()).unwrap();
@@ -429,8 +429,8 @@ mod tests {
 
     #[test]
     fn test_generate_plot_from_networks_multi_two_port() {
-        let n1 = Network::new("files/ntwk1.s2p".to_string());
-        let n2 = Network::new("files/ntwk2.s2p".to_string());
+        let n1 = Network::new("files/ntwk1.s2p").unwrap();
+        let n2 = Network::new("files/ntwk2.s2p").unwrap();
         let test_dir = setup_test_dir("test_plot_multi_two_port");
         let output_path = test_dir.join("overlay.html");
         generate_plot_from_networks(&[n1, n2], output_path.to_str().unwrap()).unwrap();
@@ -446,7 +446,7 @@ mod tests {
         let s2p_path = test_dir.join("test_plot.s2p");
         fs::copy("files/test_plot/test_plot.s2p", &s2p_path).unwrap();
 
-        let network = Network::new(s2p_path.to_str().unwrap().to_string());
+        let network = Network::new(s2p_path.to_str().unwrap()).unwrap();
 
         // network.name is derived from filename, so it will be "test_plot.s2p" (or similar depending on implementation)
         // Network::new uses parser::read_file which sets name.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,13 @@
+use crate::TouchstoneError;
+
+pub(crate) fn try_str_to_f64(x: &str) -> Result<f64, TouchstoneError> {
+    x.parse::<f64>()
+        .map_err(|_| TouchstoneError::InvalidNumber {
+            token: x.to_string(),
+        })
+}
+
+#[cfg(test)]
 pub(crate) fn str_to_f64(x: &str) -> f64 {
     x.parse::<f64>().expect("Failed to parse {x} into f64")
 }

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -1,6 +1,6 @@
 //! Edge case and error handling integration tests for the touchstone crate.
 
-use touchstone::Network;
+use touchstone::{Network, TouchstoneError};
 
 // ============================================================
 // 1-port file parsing
@@ -8,7 +8,7 @@ use touchstone::Network;
 
 #[test]
 fn parse_s1p_hfss_oneport() {
-    let ntwk = Network::new("files/hfss_oneport.s1p".to_string());
+    let ntwk = Network::new("files/hfss_oneport.s1p").unwrap();
     assert_eq!(ntwk.rank, 1);
     assert!(!ntwk.f.is_empty());
     assert_eq!(ntwk.frequency_unit, "GHz");
@@ -17,14 +17,14 @@ fn parse_s1p_hfss_oneport() {
 
 #[test]
 fn parse_s1p_powerwave() {
-    let ntwk = Network::new("files/hfss_oneport_powerwave.s1p".to_string());
+    let ntwk = Network::new("files/hfss_oneport_powerwave.s1p").unwrap();
     assert_eq!(ntwk.rank, 1);
     assert!(!ntwk.f.is_empty());
 }
 
 #[test]
 fn s1p_s_parameters_all_formats() {
-    let ntwk = Network::new("files/hfss_oneport.s1p".to_string());
+    let ntwk = Network::new("files/hfss_oneport.s1p").unwrap();
 
     // Only S11 exists for 1-port
     let s11_db = ntwk.s_db(1, 1);
@@ -48,7 +48,7 @@ fn s1p_s_parameters_all_formats() {
 
 #[test]
 fn parse_s4p_agilent() {
-    let ntwk = Network::new("files/Agilent_E5071B.s4p".to_string());
+    let ntwk = Network::new("files/Agilent_E5071B.s4p").unwrap();
     assert_eq!(ntwk.rank, 4);
     assert!(!ntwk.f.is_empty());
     // This file uses Hz and dB format with 75 ohm impedance
@@ -59,14 +59,14 @@ fn parse_s4p_agilent() {
 
 #[test]
 fn parse_s4p_rs_znb8() {
-    let ntwk = Network::new("files/RS_ZNB8.s4p".to_string());
+    let ntwk = Network::new("files/RS_ZNB8.s4p").unwrap();
     assert_eq!(ntwk.rank, 4);
     assert!(!ntwk.f.is_empty());
 }
 
 #[test]
 fn s4p_all_port_combinations() {
-    let ntwk = Network::new("files/Agilent_E5071B.s4p".to_string());
+    let ntwk = Network::new("files/Agilent_E5071B.s4p").unwrap();
 
     // Access all 16 S-parameter combinations for a 4-port
     for j in 1..=4 {
@@ -98,7 +98,7 @@ fn s4p_all_port_combinations() {
 #[test]
 fn option_line_ghz_ma() {
     // hfss_oneport.s1p uses: # GHZ S MA
-    let ntwk = Network::new("files/hfss_oneport.s1p".to_string());
+    let ntwk = Network::new("files/hfss_oneport.s1p").unwrap();
     assert_eq!(ntwk.frequency_unit, "GHz");
     assert_eq!(ntwk.format, "MA");
     assert!((ntwk.z0 - 50.0).abs() < 0.01);
@@ -107,7 +107,7 @@ fn option_line_ghz_ma() {
 #[test]
 fn option_line_ghz_db() {
     // hfss_threeport_DB.s3p uses: # GHZ S DB
-    let ntwk = Network::new("files/hfss_threeport_DB.s3p".to_string());
+    let ntwk = Network::new("files/hfss_threeport_DB.s3p").unwrap();
     assert_eq!(ntwk.frequency_unit, "GHz");
     assert_eq!(ntwk.format, "DB");
 }
@@ -115,7 +115,7 @@ fn option_line_ghz_db() {
 #[test]
 fn option_line_hz_db_75ohm() {
     // Agilent_E5071B.s4p uses: # Hz S dB R 75
-    let ntwk = Network::new("files/Agilent_E5071B.s4p".to_string());
+    let ntwk = Network::new("files/Agilent_E5071B.s4p").unwrap();
     assert_eq!(ntwk.frequency_unit, "Hz");
     assert_eq!(ntwk.format, "DB");
     assert!((ntwk.z0 - 75.0).abs() < 0.01);
@@ -124,8 +124,8 @@ fn option_line_hz_db_75ohm() {
 #[test]
 fn option_line_50ohm_threeport_variants() {
     // Files with explicit 50 ohm
-    let db50 = Network::new("files/hfss_threeport_DB_50Ohm.s3p".to_string());
-    let ma50 = Network::new("files/hfss_threeport_MA_50Ohm.s3p".to_string());
+    let db50 = Network::new("files/hfss_threeport_DB_50Ohm.s3p").unwrap();
+    let ma50 = Network::new("files/hfss_threeport_MA_50Ohm.s3p").unwrap();
     assert!((db50.z0 - 50.0).abs() < 0.01);
     assert!((ma50.z0 - 50.0).abs() < 0.01);
 }
@@ -136,8 +136,8 @@ fn option_line_50ohm_threeport_variants() {
 
 #[test]
 fn cascade_produces_valid_data() {
-    let net1 = Network::new("files/ntwk1.s2p".to_string());
-    let net2 = Network::new("files/ntwk2.s2p".to_string());
+    let net1 = Network::new("files/ntwk1.s2p").unwrap();
+    let net2 = Network::new("files/ntwk2.s2p").unwrap();
     let cascaded = net1.cascade(&net2);
 
     assert_eq!(cascaded.rank, 2);
@@ -153,10 +153,10 @@ fn cascade_produces_valid_data() {
 
 #[test]
 fn cascade_matches_reference_file() {
-    let net1 = Network::new("files/ntwk1.s2p".to_string());
-    let net2 = Network::new("files/ntwk2.s2p".to_string());
+    let net1 = Network::new("files/ntwk1.s2p").unwrap();
+    let net2 = Network::new("files/ntwk2.s2p").unwrap();
     let cascaded = net1.cascade(&net2);
-    let reference = Network::new("files/cascade_ntwk1_ntwk2.s2p".to_string());
+    let reference = Network::new("files/cascade_ntwk1_ntwk2.s2p").unwrap();
 
     assert_eq!(cascaded.f.len(), reference.f.len());
 
@@ -178,9 +178,9 @@ fn cascade_matches_reference_file() {
 
 #[test]
 fn mul_trait_cascade() {
-    let net1 = Network::new("files/ntwk1.s2p".to_string());
+    let net1 = Network::new("files/ntwk1.s2p").unwrap();
     let expected_len = net1.f.len();
-    let net2 = Network::new("files/ntwk2.s2p".to_string());
+    let net2 = Network::new("files/ntwk2.s2p").unwrap();
 
     // Mul trait should also work
     let cascaded = net1 * net2;
@@ -191,7 +191,7 @@ fn mul_trait_cascade() {
 #[test]
 fn s_db_ri_ma_consistency() {
     // Verify that DB, RI, and MA representations are consistent for the same data
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
 
     let s11_db = ntwk.s_db(1, 1);
     let s11_ri = ntwk.s_ri(1, 1);
@@ -245,15 +245,28 @@ fn s_db_ri_ma_consistency() {
 // ============================================================
 
 #[test]
-#[should_panic]
-fn nonexistent_file_panics() {
-    let _ = Network::new("files/does_not_exist.s2p".to_string());
+fn nonexistent_file_returns_error() {
+    let error = Network::new("files/does_not_exist.s2p").unwrap_err();
+
+    assert!(matches!(error, TouchstoneError::Io(_)));
 }
 
 #[test]
-#[should_panic]
-fn invalid_extension_panics() {
-    let _ = Network::new("files/ntwk1.txt".to_string());
+fn invalid_extension_returns_error() {
+    let path = std::env::temp_dir().join("touchstone_invalid_extension.txt");
+    std::fs::write(
+        &path,
+        "# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n",
+    )
+    .unwrap();
+
+    let error = Network::new(&path).unwrap_err();
+    std::fs::remove_file(path).unwrap();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::UnsupportedFileType { file_type } if file_type == "txt"
+    ));
 }
 
 // ============================================================
@@ -262,11 +275,11 @@ fn invalid_extension_panics() {
 
 #[test]
 fn round_trip_s2p() {
-    let original = Network::new("files/ntwk1.s2p".to_string());
+    let original = Network::new("files/ntwk1.s2p").unwrap();
     let tmp = "files/test_round_trip_edge.s2p";
 
     original.save(tmp).unwrap();
-    let reloaded = Network::new(tmp.to_string());
+    let reloaded = Network::new(tmp).unwrap();
 
     assert_eq!(original.rank, reloaded.rank);
     assert_eq!(original.f.len(), reloaded.f.len());
@@ -301,11 +314,11 @@ fn round_trip_s2p() {
 
 #[test]
 fn round_trip_s3p() {
-    let original = Network::new("files/hfss_threeport_DB.s3p".to_string());
+    let original = Network::new("files/hfss_threeport_DB.s3p").unwrap();
     let tmp = "files/test_round_trip_s3p.s3p";
 
     original.save(tmp).unwrap();
-    let reloaded = Network::new(tmp.to_string());
+    let reloaded = Network::new(tmp).unwrap();
 
     assert_eq!(original.rank, reloaded.rank);
     assert_eq!(original.f.len(), reloaded.f.len());
@@ -329,13 +342,13 @@ fn round_trip_s3p() {
 
 #[test]
 fn round_trip_preserves_cascade_result() {
-    let net1 = Network::new("files/ntwk1.s2p".to_string());
-    let net2 = Network::new("files/ntwk2.s2p".to_string());
+    let net1 = Network::new("files/ntwk1.s2p").unwrap();
+    let net2 = Network::new("files/ntwk2.s2p").unwrap();
     let cascaded = net1.cascade(&net2);
 
     let tmp = "files/test_round_trip_cascade.s2p";
     cascaded.save(tmp).unwrap();
-    let reloaded = Network::new(tmp.to_string());
+    let reloaded = Network::new(tmp).unwrap();
 
     assert_eq!(cascaded.f.len(), reloaded.f.len());
 
@@ -359,21 +372,21 @@ fn round_trip_preserves_cascade_result() {
 
 #[test]
 fn parse_s32p() {
-    let ntwk = Network::new("files/ntwk.s32p".to_string());
+    let ntwk = Network::new("files/ntwk.s32p").unwrap();
     assert_eq!(ntwk.rank, 32);
     assert!(!ntwk.f.is_empty());
 }
 
 #[test]
 fn parse_s8p() {
-    let ntwk = Network::new("files/hfss_19.2.s8p".to_string());
+    let ntwk = Network::new("files/hfss_19.2.s8p").unwrap();
     assert_eq!(ntwk.rank, 8);
     assert!(!ntwk.f.is_empty());
 }
 
 #[test]
 fn parse_s10p() {
-    let ntwk = Network::new("files/hfss_19.2.s10p".to_string());
+    let ntwk = Network::new("files/hfss_19.2.s10p").unwrap();
     assert_eq!(ntwk.rank, 10);
     assert!(!ntwk.f.is_empty());
 }
@@ -393,7 +406,7 @@ fn parse_all_threeport_variants() {
     ];
 
     for file in files {
-        let ntwk = Network::new(file.to_string());
+        let ntwk = Network::new(file).unwrap();
         assert_eq!(ntwk.rank, 3, "Wrong rank for {}", file);
         assert!(!ntwk.f.is_empty(), "No frequencies for {}", file);
     }

--- a/tests/in_memory_network.rs
+++ b/tests/in_memory_network.rs
@@ -1,0 +1,65 @@
+use touchstone::{Network, TouchstoneError};
+
+const TWO_PORT_RI: &str = "# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n";
+
+#[test]
+fn try_new_reads_existing_touchstone_file() {
+    let network = Network::try_new("files/ntwk1.s2p").unwrap();
+
+    assert_eq!(network.name, "files/ntwk1.s2p");
+    assert_eq!(network.rank, 2);
+    assert!(!network.f.is_empty());
+}
+
+#[test]
+fn from_str_parses_uploaded_touchstone_data_without_file() {
+    let network = Network::from_str("uploaded.s2p", TWO_PORT_RI).unwrap();
+
+    assert_eq!(network.name, "uploaded.s2p");
+    assert_eq!(network.rank, 2);
+    assert_eq!(network.frequency_unit, "GHz");
+    assert_eq!(network.z0, 50.0);
+    assert_eq!(network.f, vec![1.0e9]);
+    assert_eq!(network.s_ri(2, 1)[0].s_ri.0, 4.0);
+    assert_eq!(network.s_ri(1, 2)[0].s_ri.0, 0.01);
+}
+
+#[test]
+fn from_bytes_parses_uploaded_touchstone_data_without_file() {
+    let network = Network::from_bytes("uploaded.s2p", TWO_PORT_RI.as_bytes()).unwrap();
+
+    assert_eq!(network.name, "uploaded.s2p");
+    assert_eq!(network.rank, 2);
+    assert_eq!(network.s_ri(2, 1)[0].s_ri.0, 4.0);
+    assert_eq!(network.s_ri(1, 2)[0].s_ri.0, 0.01);
+}
+
+#[test]
+fn from_bytes_returns_utf8_errors() {
+    let error = Network::from_bytes("uploaded.s1p", &[0xff]).unwrap_err();
+
+    assert!(matches!(error, TouchstoneError::InvalidUtf8(_)));
+}
+
+#[test]
+fn from_str_returns_unsupported_file_type_errors() {
+    let error = Network::from_str("uploaded.txt", TWO_PORT_RI).unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::UnsupportedFileType { file_type } if file_type == "txt"
+    ));
+}
+
+#[test]
+fn from_str_returns_malformed_data_errors() {
+    let error = Network::from_str("uploaded.s1p", "# GHz S RI R 50\n1.0 0.1\n").unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidDataLineParts {
+            expected: 3,
+            actual: 2
+        }
+    ));
+}

--- a/tests/in_memory_network.rs
+++ b/tests/in_memory_network.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use touchstone::{Network, TouchstoneError};
 
 const TWO_PORT_RI: &str = "# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n";
@@ -35,6 +37,16 @@ fn from_bytes_parses_uploaded_touchstone_data_without_file() {
 }
 
 #[test]
+fn from_memory_matches_try_new_for_s1p_file() {
+    assert_from_memory_matches_try_new("files/hfss_oneport.s1p");
+}
+
+#[test]
+fn from_memory_matches_try_new_for_s3p_file() {
+    assert_from_memory_matches_try_new("files/hfss_18.2.s3p");
+}
+
+#[test]
 fn from_bytes_returns_utf8_errors() {
     let error = Network::from_bytes("uploaded.s1p", &[0xff]).unwrap_err();
 
@@ -62,4 +74,48 @@ fn from_str_returns_malformed_data_errors() {
             actual: 2
         }
     ));
+}
+
+fn assert_from_memory_matches_try_new(path: &str) {
+    let contents = fs::read_to_string(path).unwrap();
+    let bytes = fs::read(path).unwrap();
+
+    let from_file = Network::try_new(path).unwrap();
+    let from_str = Network::from_str(path, &contents).unwrap();
+    let from_bytes = Network::from_bytes(path, &bytes).unwrap();
+
+    assert_same_network_shape(path, &from_file, &from_str);
+    assert_same_network_shape(path, &from_file, &from_bytes);
+}
+
+fn assert_same_network_shape(path: &str, left: &Network, right: &Network) {
+    assert_eq!(left.name, right.name, "{path}");
+    assert_eq!(left.rank, right.rank, "{path}");
+    assert_eq!(left.frequency_unit, right.frequency_unit, "{path}");
+    assert_eq!(left.parameter, right.parameter, "{path}");
+    assert_eq!(left.format, right.format, "{path}");
+    assert_eq!(left.resistance_string, right.resistance_string, "{path}");
+    assert_eq!(left.z0, right.z0, "{path}");
+    assert_eq!(left.comments, right.comments, "{path}");
+    assert_eq!(
+        left.comments_after_option_line, right.comments_after_option_line,
+        "{path}"
+    );
+    assert_eq!(left.f, right.f, "{path}");
+    assert_eq!(left.s.len(), right.s.len(), "{path}");
+
+    for j in 1..=left.rank {
+        for k in 1..=left.rank {
+            let left_s = left.s_ri(j as i8, k as i8);
+            let right_s = right.s_ri(j as i8, k as i8);
+            assert_eq!(left_s.len(), right_s.len(), "{path} S{j}{k}");
+            for (left_point, right_point) in left_s.iter().zip(right_s) {
+                assert_eq!(
+                    left_point.frequency, right_point.frequency,
+                    "{path} S{j}{k}"
+                );
+                assert_eq!(left_point.s_ri, right_point.s_ri, "{path} S{j}{k}");
+            }
+        }
+    }
 }

--- a/tests/in_memory_network.rs
+++ b/tests/in_memory_network.rs
@@ -5,8 +5,8 @@ use touchstone::{Network, TouchstoneError};
 const TWO_PORT_RI: &str = "# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n";
 
 #[test]
-fn try_new_reads_existing_touchstone_file() {
-    let network = Network::try_new("files/ntwk1.s2p").unwrap();
+fn new_reads_existing_touchstone_file() {
+    let network = Network::new("files/ntwk1.s2p").unwrap();
 
     assert_eq!(network.name, "files/ntwk1.s2p");
     assert_eq!(network.rank, 2);
@@ -37,13 +37,13 @@ fn from_bytes_parses_uploaded_touchstone_data_without_file() {
 }
 
 #[test]
-fn from_memory_matches_try_new_for_s1p_file() {
-    assert_from_memory_matches_try_new("files/hfss_oneport.s1p");
+fn from_memory_matches_new_for_s1p_file() {
+    assert_from_memory_matches_new("files/hfss_oneport.s1p");
 }
 
 #[test]
-fn from_memory_matches_try_new_for_s3p_file() {
-    assert_from_memory_matches_try_new("files/hfss_18.2.s3p");
+fn from_memory_matches_new_for_s3p_file() {
+    assert_from_memory_matches_new("files/hfss_18.2.s3p");
 }
 
 #[test]
@@ -76,11 +76,11 @@ fn from_str_returns_malformed_data_errors() {
     ));
 }
 
-fn assert_from_memory_matches_try_new(path: &str) {
+fn assert_from_memory_matches_new(path: &str) {
     let contents = fs::read_to_string(path).unwrap();
     let bytes = fs::read(path).unwrap();
 
-    let from_file = Network::try_new(path).unwrap();
+    let from_file = Network::new(path).unwrap();
     let from_str = Network::from_str(path, &contents).unwrap();
     let from_bytes = Network::from_bytes(path, &bytes).unwrap();
 

--- a/tests/readme_examples.rs
+++ b/tests/readme_examples.rs
@@ -6,7 +6,7 @@ use touchstone::Network;
 
 #[test]
 fn loading_a_network() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
 
     assert_eq!(ntwk.rank, 2);
     assert!(!ntwk.frequency_unit.is_empty());
@@ -19,7 +19,7 @@ fn loading_a_network() {
 
 #[test]
 fn s_parameters_db() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
 
     let s11_db = ntwk.s_db(1, 1);
     assert_eq!(s11_db.len(), ntwk.f.len());
@@ -33,7 +33,7 @@ fn s_parameters_db() {
 
 #[test]
 fn s_parameters_ri() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
 
     let s21_ri = ntwk.s_ri(2, 1);
     assert_eq!(s21_ri.len(), ntwk.f.len());
@@ -46,7 +46,7 @@ fn s_parameters_ri() {
 
 #[test]
 fn s_parameters_ma() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
 
     let s21_ma = ntwk.s_ma(2, 1);
     assert_eq!(s21_ma.len(), ntwk.f.len());
@@ -59,7 +59,7 @@ fn s_parameters_ma() {
 
 #[test]
 fn field_aliases_ri() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
     let s11_ri = ntwk.s_ri(1, 1);
     let point = &s11_ri[0];
 
@@ -77,7 +77,7 @@ fn field_aliases_ri() {
 
 #[test]
 fn field_aliases_db() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
     let s11_db = ntwk.s_db(1, 1);
     let point = &s11_db[0];
 
@@ -90,7 +90,7 @@ fn field_aliases_db() {
 
 #[test]
 fn field_aliases_ma() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
     let s21_ma = ntwk.s_ma(2, 1);
     let point = &s21_ma[0];
 
@@ -109,13 +109,13 @@ fn field_aliases_ma() {
 
 #[test]
 fn save_network() {
-    let ntwk = Network::new("files/ntwk1.s2p".to_string());
+    let ntwk = Network::new("files/ntwk1.s2p").unwrap();
     let tmp_path = "files/test_save_readme.s2p";
 
     ntwk.save(tmp_path).unwrap();
 
     // Verify round-trip
-    let reloaded = Network::new(tmp_path.to_string());
+    let reloaded = Network::new(tmp_path).unwrap();
     assert_eq!(reloaded.rank, ntwk.rank);
     assert_eq!(reloaded.f.len(), ntwk.f.len());
 
@@ -127,8 +127,8 @@ fn save_network() {
 
 #[test]
 fn cascade_networks() {
-    let net1 = Network::new("files/ntwk1.s2p".to_string());
-    let net2 = Network::new("files/ntwk2.s2p".to_string());
+    let net1 = Network::new("files/ntwk1.s2p").unwrap();
+    let net2 = Network::new("files/ntwk2.s2p").unwrap();
 
     let cascaded = net1.cascade(&net2);
     assert_eq!(cascaded.rank, 2);
@@ -138,8 +138,8 @@ fn cascade_networks() {
 
 #[test]
 fn cascade_ports() {
-    let net1 = Network::new("files/ntwk1.s2p".to_string());
-    let net2 = Network::new("files/ntwk2.s2p".to_string());
+    let net1 = Network::new("files/ntwk1.s2p").unwrap();
+    let net2 = Network::new("files/ntwk2.s2p").unwrap();
 
     let cascaded = net1.cascade_ports(&net2, 2, 1);
     assert_eq!(cascaded.rank, 2);
@@ -150,18 +150,18 @@ fn cascade_ports() {
 
 #[test]
 fn load_1port() {
-    let ntwk = Network::new("files/hfss_oneport.s1p".to_string());
+    let ntwk = Network::new("files/hfss_oneport.s1p").unwrap();
     assert_eq!(ntwk.rank, 1);
 }
 
 #[test]
 fn load_3port() {
-    let ntwk = Network::new("files/hfss_18.2.s3p".to_string());
+    let ntwk = Network::new("files/hfss_18.2.s3p").unwrap();
     assert_eq!(ntwk.rank, 3);
 }
 
 #[test]
 fn load_4port() {
-    let ntwk = Network::new("files/Agilent_E5071B.s4p".to_string());
+    let ntwk = Network::new("files/Agilent_E5071B.s4p").unwrap();
     assert_eq!(ntwk.rank, 4);
 }


### PR DESCRIPTION
## Summary

Adds fallible in-memory parsing APIs for Touchstone data and makes file parsing fallible by default:

- breaking change for `0.13.0`: `Network::new(path) -> Result<Network, TouchstoneError>`
- removes the duplicate public `Network::try_new(path)` constructor
- adds `Network::from_bytes(source_name, bytes)` for uploaded/API-provided bytes
- adds `Network::from_str(source_name, contents)` for uploaded/API-provided strings
- exposes `TouchstoneError` variants for ordinary parse, UTF-8, extension, keyword, and I/O failures

## Notes

- Splits file reading from contents parsing so callers no longer need temporary `.sNp` files.
- Keeps `.sNp` extension inference through `source_name`, matching the current parser model.
- Converts data-line and keyword parser failures used by the new APIs into structured errors.
- Updates README/rustdoc examples and call sites for the fallible `Network::new` API.
- Bumps the crate version from `0.12.2` to `0.13.0` because this is a pre-1.0 breaking API change.

Closes #53.

## Validation

- `just check`
- `cargo doc --no-deps`