### PR TITLE
chore: add open source project polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a reproducible problem with touchstone.
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please include enough detail for the issue to be reproduced.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: Describe the observed behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest command, code sample, or Touchstone input that reproduces the issue.
+      placeholder: |
+        1. Run `...`
+        2. Open `...`
+        3. See `...`
+    validations:
+      required: true
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      description: Which part of touchstone appears to be affected?
+      options:
+        - Parser
+        - Writer / serialization
+        - CLI plotting
+        - Cascade
+        - S-parameter accessors
+        - Documentation
+        - Other / unsure
+    validations:
+      required: true
+  - type: textarea
+    id: touchstone-shape
+    attributes:
+      label: Touchstone input shape
+      description: Describe the input file or generated network data, if applicable.
+      placeholder: |
+        - File extension / port count:
+        - Option line:
+        - Data format: RI / MA / DB
+        - Touchstone version or keywords:
+        - Smallest redacted sample:
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include versions and platform details.
+      placeholder: |
+        - touchstone version:
+        - Rust version:
+        - OS:
+        - Command or API used:
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add logs, warnings, sample file notes, or related links.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an improvement or new capability for touchstone.
+title: "Feature: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please describe the use case and the expected behavior.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Use case
+      description: What workflow, limitation, or problem would this feature address?
+      placeholder: Describe the engineering workflow this would improve.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should touchstone do?
+      placeholder: Describe the API, CLI behavior, parser support, or output you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Are there existing workarounds or different designs worth considering?
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add links, examples, sample Touchstone files, or standards references if helpful.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,24 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
-  build_and_test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Use Rust stable
-        run: rustup update stable && rustup default stable
-      - name: Build project
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-      - name: Publish (on tag)
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add rustfmt clippy
+      - name: Install just
+        run: cargo install just --locked
+      - name: Run contributor checks
+        run: just ci
+      - name: Publish crate
         if: github.ref_type == 'tag'
         run: cargo publish --verbose
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+Thanks for helping improve touchstone. This crate is a Rust project for parsing,
+analyzing, writing, and plotting Touchstone SNP files.
+
+## Toolchain
+
+Use the stable Rust toolchain with `rustfmt` and `clippy` installed:
+
+```bash
+rustup update stable
+rustup default stable
+rustup component add rustfmt clippy
+```
+
+This repository uses `just` as the task runner. Install it with Cargo if it is
+not already available:
+
+```bash
+cargo install just --locked
+```
+
+List available project commands with:
+
+```bash
+just --list
+```
+
+## Local checks
+
+Before opening a pull request, run the same checks that CI runs:
+
+```bash
+just ci
+```
+
+`just ci` runs formatting verification, clippy with warnings denied, tests, and
+a debug build. The individual commands are also available:
+
+```bash
+just fmt-check
+just lint
+just test
+just build
+```
+
+Use `just fmt` to apply Rust formatting before committing.
+
+## Pull requests
+
+- Keep changes focused and include tests when behavior changes.
+- Update documentation or examples when public APIs or CLI behavior changes.
+- Do not commit generated plot HTML or local build artifacts unless they are
+  intentionally part of the change.
+- Include enough context in the pull request description for reviewers to
+  understand the motivation and validation performed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ian Cleary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add an MIT `LICENSE` file matching the crate metadata.
- Add contributor setup and validation notes in `CONTRIBUTING.md`.
- Add GitHub bug and feature request templates.
- Update CI to run the documented contributor path through `just ci`.

Closes #67

## Validation

- `just ci`
- `git diff --check`
