### PR TITLE
feat: expose stable matrix access APIs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a reproducible problem with touchstone.
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please include enough detail for the issue to be reproduced.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: Describe the observed behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest command, code sample, or Touchstone input that reproduces the issue.
+      placeholder: |
+        1. Run `...`
+        2. Open `...`
+        3. See `...`
+    validations:
+      required: true
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected area
+      description: Which part of touchstone appears to be affected?
+      options:
+        - Parser
+        - Writer / serialization
+        - CLI plotting
+        - Cascade
+        - S-parameter accessors
+        - Documentation
+        - Other / unsure
+    validations:
+      required: true
+  - type: textarea
+    id: touchstone-shape
+    attributes:
+      label: Touchstone input shape
+      description: Describe the input file or generated network data, if applicable.
+      placeholder: |
+        - File extension / port count:
+        - Option line:
+        - Data format: RI / MA / DB
+        - Touchstone version or keywords:
+        - Smallest redacted sample:
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include versions and platform details.
+      placeholder: |
+        - touchstone version:
+        - Rust version:
+        - OS:
+        - Command or API used:
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add logs, warnings, sample file notes, or related links.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an improvement or new capability for touchstone.
+title: "Feature: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please describe the use case and the expected behavior.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Use case
+      description: What workflow, limitation, or problem would this feature address?
+      placeholder: Describe the engineering workflow this would improve.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should touchstone do?
+      placeholder: Describe the API, CLI behavior, parser support, or output you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Are there existing workarounds or different designs worth considering?
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add links, examples, sample Touchstone files, or standards references if helpful.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,24 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
-  build_and_test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Use Rust stable
-        run: rustup update stable && rustup default stable
-      - name: Build project
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-      - name: Publish (on tag)
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add rustfmt clippy
+      - name: Install just
+        run: cargo install just --locked
+      - name: Run contributor checks
+        run: just ci
+      - name: Publish crate
         if: github.ref_type == 'tag'
         run: cargo publish --verbose
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+Thanks for helping improve touchstone. This crate is a Rust project for parsing,
+analyzing, writing, and plotting Touchstone SNP files.
+
+## Toolchain
+
+Use the stable Rust toolchain with `rustfmt` and `clippy` installed:
+
+```bash
+rustup update stable
+rustup default stable
+rustup component add rustfmt clippy
+```
+
+This repository uses `just` as the task runner. Install it with Cargo if it is
+not already available:
+
+```bash
+cargo install just --locked
+```
+
+List available project commands with:
+
+```bash
+just --list
+```
+
+## Local checks
+
+Before opening a pull request, run the same checks that CI runs:
+
+```bash
+just ci
+```
+
+`just ci` runs formatting verification, clippy with warnings denied, tests, and
+a debug build. The individual commands are also available:
+
+```bash
+just fmt-check
+just lint
+just test
+just build
+```
+
+Use `just fmt` to apply Rust formatting before committing.
+
+## Pull requests
+
+- Keep changes focused and include tests when behavior changes.
+- Update documentation or examples when public APIs or CLI behavior changes.
+- Do not commit generated plot HTML or local build artifacts unless they are
+  intentionally part of the change.
+- Include enough context in the pull request description for reviewers to
+  understand the motivation and validation performed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ian Cleary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/error.rs
+++ b/src/error.rs
@@ -182,6 +182,22 @@ pub enum TouchstoneError {
         /// Matrix format token from the keyword.
         format: String,
     },
+    /// A requested 0-based frequency point index was outside the parsed data range.
+    InvalidPointIndex {
+        /// Requested 0-based frequency point index.
+        point_index: usize,
+        /// Number of parsed frequency points.
+        point_count: usize,
+    },
+    /// A requested 1-based S-parameter port index was outside the network port range.
+    InvalidPortIndex {
+        /// Requested destination/output port, using 1-based RF indexing.
+        to_port: usize,
+        /// Requested source/input port, using 1-based RF indexing.
+        from_port: usize,
+        /// Number of ports in the network or matrix.
+        rank: usize,
+    },
 }
 
 impl TouchstoneError {
@@ -299,6 +315,21 @@ impl fmt::Display for TouchstoneError {
             Self::UnsupportedMatrixFormat { format } => {
                 write!(f, "unsupported [Matrix Format] value: {format}")
             }
+            Self::InvalidPointIndex {
+                point_index,
+                point_count,
+            } => write!(
+                f,
+                "frequency point index {point_index} out of range for {point_count} points"
+            ),
+            Self::InvalidPortIndex {
+                to_port,
+                from_port,
+                rank,
+            } => write!(
+                f,
+                "S-parameter port index S{to_port}{from_port} out of range for {rank}-port network"
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,71 @@ pub struct FrequencyMA {
     pub s_ma: data_pairs::MagnitudeAngle,
 }
 
+/// Stable complex number representation used by public matrix accessors.
+///
+/// This type intentionally does not expose the crate's internal parser matrix types.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Complex {
+    /// Real component.
+    pub re: f64,
+    /// Imaginary component.
+    pub im: f64,
+}
+
+/// Stable S-parameter matrix for one frequency point.
+///
+/// `data` is arranged as rows of destination/output ports and columns of source/input ports.
+/// Use [`SMatrix::get`] for non-panicking 1-based RF port indexing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SMatrix {
+    /// Number of ports in this square S-parameter matrix.
+    pub rank: usize,
+    /// Matrix values in row-major order.
+    pub data: Vec<Vec<Complex>>,
+}
+
+impl SMatrix {
+    /// Return S(to_port, from_port) using 1-based RF port indexes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use touchstone::{Complex, SMatrix};
+    ///
+    /// let matrix = SMatrix {
+    ///     rank: 1,
+    ///     data: vec![vec![Complex { re: 0.5, im: -0.1 }]],
+    /// };
+    ///
+    /// assert_eq!(matrix.get(1, 1)?.re, 0.5);
+    /// # Ok::<(), touchstone::TouchstoneError>(())
+    /// ```
+    pub fn get(&self, to_port: usize, from_port: usize) -> Result<Complex, TouchstoneError> {
+        validate_port_indexes(to_port, from_port, self.rank)?;
+        self.data
+            .get(to_port - 1)
+            .and_then(|row| row.get(from_port - 1))
+            .copied()
+            .ok_or(TouchstoneError::InvalidPortIndex {
+                to_port,
+                from_port,
+                rank: self.rank,
+            })
+    }
+}
+
+/// Stable network data for one frequency point.
+///
+/// Frequency point indexes on [`Network`] are 0-based. RF port indexes within [`SMatrix`] are
+/// 1-based.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NetworkPoint {
+    /// Frequency in Hz.
+    pub frequency: f64,
+    /// S-parameter matrix at this frequency.
+    pub s: SMatrix,
+}
+
 impl Network {
     /// Parse a Touchstone file and return a [`Network`].
     ///
@@ -326,6 +391,89 @@ impl Network {
             s_ma_vector.push(frequency_ma);
         }
         s_ma_vector
+    }
+
+    /// Return S(to_port, from_port) in real/imaginary form at one frequency point.
+    ///
+    /// `point_index` is 0-based. `to_port` and `from_port` use 1-based RF port indexes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use touchstone::{Complex, Network};
+    ///
+    /// let net = Network::from_str(
+    ///     "uploaded.s1p",
+    ///     "# GHz S RI R 50\n1.0 0.5 -0.1\n",
+    /// )?;
+    ///
+    /// assert_eq!(net.try_s_ri_at(0, 1, 1)?, Complex { re: 0.5, im: -0.1 });
+    /// # Ok::<(), touchstone::TouchstoneError>(())
+    /// ```
+    pub fn try_s_ri_at(
+        &self,
+        point_index: usize,
+        to_port: usize,
+        from_port: usize,
+    ) -> Result<Complex, TouchstoneError> {
+        let data_line = self.data_line_at(point_index)?;
+        let rank = data_line.s_ri.size();
+        validate_port_indexes(to_port, from_port, rank)?;
+        Ok(complex_from_real_imaginary(
+            data_line.s_ri.get(to_port, from_port),
+        ))
+    }
+
+    /// Return the full S-parameter matrix at one frequency point.
+    ///
+    /// `point_index` is 0-based. Values in the returned [`SMatrix`] can be accessed with
+    /// 1-based RF port indexes using [`SMatrix::get`].
+    pub fn s_matrix_at(&self, point_index: usize) -> Result<SMatrix, TouchstoneError> {
+        let data_line = self.data_line_at(point_index)?;
+        let rank = data_line.s_ri.size();
+        let mut data = Vec::with_capacity(rank);
+
+        for to_port in 1..=rank {
+            let mut row = Vec::with_capacity(rank);
+            for from_port in 1..=rank {
+                row.push(complex_from_real_imaginary(
+                    data_line.s_ri.get(to_port, from_port),
+                ));
+            }
+            data.push(row);
+        }
+
+        Ok(SMatrix { rank, data })
+    }
+
+    /// Return all stable data for one frequency point.
+    ///
+    /// `point_index` is 0-based.
+    pub fn point_at(&self, point_index: usize) -> Result<NetworkPoint, TouchstoneError> {
+        let data_line = self.data_line_at(point_index)?;
+        Ok(NetworkPoint {
+            frequency: data_line.frequency,
+            s: self.s_matrix_at(point_index)?,
+        })
+    }
+
+    /// Return stable data for every parsed frequency point.
+    pub fn points(&self) -> Result<Vec<NetworkPoint>, TouchstoneError> {
+        (0..self.s.len())
+            .map(|point_index| self.point_at(point_index))
+            .collect()
+    }
+
+    fn data_line_at(
+        &self,
+        point_index: usize,
+    ) -> Result<&data_line::ParsedDataLine, TouchstoneError> {
+        self.s
+            .get(point_index)
+            .ok_or(TouchstoneError::InvalidPointIndex {
+                point_index,
+                point_count: self.s.len(),
+            })
     }
 
     /// Cascade two 2-port networks (standard connection: port 2 → port 1).
@@ -736,6 +884,29 @@ fn full_matrix_data_order(n: usize) -> Vec<(usize, usize)> {
             .flat_map(|row| (1..=n).map(move |col| (row, col)))
             .collect()
     }
+}
+
+fn complex_from_real_imaginary(value: data_pairs::RealImaginary) -> Complex {
+    Complex {
+        re: value.0,
+        im: value.1,
+    }
+}
+
+fn validate_port_indexes(
+    to_port: usize,
+    from_port: usize,
+    rank: usize,
+) -> Result<(), TouchstoneError> {
+    if to_port == 0 || from_port == 0 || to_port > rank || from_port > rank {
+        return Err(TouchstoneError::InvalidPortIndex {
+            to_port,
+            from_port,
+            rank,
+        });
+    }
+
+    Ok(())
 }
 
 // The `std::ops::Mul` trait is used to specify the functionality of `+`.

--- a/tests/matrix_api.rs
+++ b/tests/matrix_api.rs
@@ -1,0 +1,88 @@
+use touchstone::{Complex, Network, TouchstoneError};
+
+const ONE_PORT_RI: &str = "# Hz S RI R 50\n1000000000 0.5 -0.25\n2000000000 0.6 -0.35\n";
+
+const TWO_PORT_ASYMMETRIC_RI: &str =
+    "# Hz S RI R 50\n1000000000 0.11 0.01 0.21 0.02 0.12 0.03 0.22 0.04\n";
+
+const THREE_PORT_RI: &str = "\
+# Hz S RI R 50
+1000000000 11 0.1 12 0.2 13 0.3 21 0.4 22 0.5 23 0.6 31 0.7 32 0.8 33 0.9
+";
+
+#[test]
+fn one_port_accessors_use_zero_based_frequency_indexes() {
+    let network = Network::from_str("uploaded.s1p", ONE_PORT_RI).unwrap();
+
+    assert_eq!(
+        network.try_s_ri_at(0, 1, 1).unwrap(),
+        Complex { re: 0.5, im: -0.25 }
+    );
+
+    let point = network.point_at(1).unwrap();
+    assert_eq!(point.frequency, 2.0e9);
+    assert_eq!(point.s.get(1, 1).unwrap(), Complex { re: 0.6, im: -0.35 });
+
+    let points = network.points().unwrap();
+    assert_eq!(points.len(), 2);
+    assert_eq!(points[0].s.rank, 1);
+    assert_eq!(points[0].s.data, vec![vec![Complex { re: 0.5, im: -0.25 }]]);
+}
+
+#[test]
+fn two_port_matrix_preserves_asymmetric_s21_and_s12() {
+    let network = Network::from_str("uploaded.s2p", TWO_PORT_ASYMMETRIC_RI).unwrap();
+    let matrix = network.s_matrix_at(0).unwrap();
+
+    assert_eq!(matrix.rank, 2);
+    assert_eq!(matrix.get(1, 1).unwrap(), Complex { re: 0.11, im: 0.01 });
+    assert_eq!(matrix.get(2, 1).unwrap(), Complex { re: 0.21, im: 0.02 });
+    assert_eq!(matrix.get(1, 2).unwrap(), Complex { re: 0.12, im: 0.03 });
+    assert_eq!(matrix.get(2, 2).unwrap(), Complex { re: 0.22, im: 0.04 });
+
+    assert_ne!(matrix.get(2, 1).unwrap(), matrix.get(1, 2).unwrap());
+}
+
+#[test]
+fn three_port_matrix_uses_one_based_rf_port_indexes() {
+    let network = Network::from_str("uploaded.s3p", THREE_PORT_RI).unwrap();
+    let matrix = network.s_matrix_at(0).unwrap();
+
+    assert_eq!(matrix.rank, 3);
+    assert_eq!(matrix.get(3, 2).unwrap(), Complex { re: 32.0, im: 0.8 });
+    assert_eq!(
+        network.try_s_ri_at(0, 2, 3).unwrap(),
+        Complex { re: 23.0, im: 0.6 }
+    );
+}
+
+#[test]
+fn invalid_point_index_returns_structured_error() {
+    let network = Network::from_str("uploaded.s1p", ONE_PORT_RI).unwrap();
+
+    let error = network.point_at(2).unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidPointIndex {
+            point_index: 2,
+            point_count: 2
+        }
+    ));
+}
+
+#[test]
+fn invalid_port_index_returns_structured_error() {
+    let network = Network::from_str("uploaded.s2p", TWO_PORT_ASYMMETRIC_RI).unwrap();
+
+    let error = network.try_s_ri_at(0, 3, 1).unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidPortIndex {
+            to_port: 3,
+            from_port: 1,
+            rank: 2
+        }
+    ));
+}


### PR DESCRIPTION
## Summary

- Add public `Complex`, `SMatrix`, and `NetworkPoint` data types for stable matrix access.
- Add non-panicking `Network` accessors for point-indexed S-parameter values and full matrices.
- Add structured errors for invalid frequency point and RF port indexes.
- Add integration tests for 1-port, asymmetric 2-port, 3-port, and invalid index behavior.

Stacked on #68.
Closes #62

## Validation

- `just ci`
- `git diff --check`
