### PR TITLE
feat: add network builder and in-memory serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ let ntwk = Network::new("files/ntwk1.s2p")?;
 ntwk.save("output.s2p").unwrap();
 ```
 
+For generated data, build a network from in-memory matrices and serialize without writing a file:
+
+```rust
+use touchstone::{Complex, NetworkBuilder, SMatrix};
+
+let ntwk = NetworkBuilder::new("generated.s1p", 1)
+    .point(
+        1.0e9,
+        SMatrix {
+            rank: 1,
+            data: vec![vec![Complex { re: 0.5, im: -0.1 }]],
+        },
+    )
+    .build()?;
+
+let touchstone = ntwk.to_touchstone_string()?;
+```
+
 ---
 
 ## 5. Cascading 2-Port Networks
@@ -317,6 +335,7 @@ If you use `touchstone` as a library, install any `tracing` subscriber in your a
 | `Network::new(path)`          | Parse a Touchstone file and return errors    |
 | `Network::from_bytes(name, bytes)` | Parse in-memory UTF-8 Touchstone bytes  |
 | `Network::from_str(name, contents)` | Parse an in-memory Touchstone string    |
+| `NetworkBuilder::new(name, rank)` | Build generated S-parameter networks     |
 | `network.rank`                | Number of ports                              |
 | `network.frequency_unit`      | Frequency unit string                        |
 | `network.format`              | Data format (`RI`, `MA`, or `DB`)            |
@@ -327,6 +346,8 @@ If you use `touchstone` as a library, install any `tracing` subscriber in your a
 | `network.s_db(j, k)`         | S_jk in dB+angle — `Vec<FrequencyDB>`       |
 | `network.s_ri(j, k)`         | S_jk in real+imag — `Vec<FrequencyRI>`       |
 | `network.s_ma(j, k)`         | S_jk in mag+angle — `Vec<FrequencyMA>`       |
+| `network.to_touchstone_string()` | Serialize Touchstone text in memory       |
+| `network.write_touchstone(writer)` | Write Touchstone text to any writer      |
 | `network.save(path)`         | Write network to file                        |
 | `network.cascade(&other)`    | Cascade two 2-port networks                  |
 | `network.cascade_ports(&other, from, to)` | Cascade with explicit port mapping |

--- a/src/error.rs
+++ b/src/error.rs
@@ -198,6 +198,67 @@ pub enum TouchstoneError {
         /// Number of ports in the network or matrix.
         rank: usize,
     },
+    /// A generated network rank was outside the supported range.
+    InvalidNetworkRank {
+        /// Requested network rank.
+        rank: usize,
+    },
+    /// The generated network rank did not match an inferable `.sNp` extension.
+    NetworkRankExtensionMismatch {
+        /// Requested network rank.
+        rank: usize,
+        /// Port count inferred from the source name extension.
+        extension_rank: usize,
+    },
+    /// A generated network did not contain any frequency points.
+    EmptyNetworkData,
+    /// A generated S-parameter matrix declared a different rank than the network.
+    InvalidMatrixRank {
+        /// 0-based frequency point index.
+        point_index: usize,
+        /// Rank declared by the matrix.
+        matrix_rank: usize,
+        /// Rank required by the network.
+        expected_rank: usize,
+    },
+    /// A generated S-parameter matrix was not shaped as a square rank-by-rank matrix.
+    InvalidMatrixShape {
+        /// 0-based frequency point index.
+        point_index: usize,
+        /// Number of rows in the matrix data.
+        rows: usize,
+        /// 0-based row index with the wrong column count, when known.
+        row_index: Option<usize>,
+        /// Number of columns in the row, or 0 when the row was missing.
+        columns: usize,
+        /// Expected row and column count.
+        expected_rank: usize,
+    },
+    /// A generated frequency was not finite.
+    InvalidFrequency {
+        /// 0-based frequency point index.
+        point_index: usize,
+        /// Invalid frequency value in Hz.
+        frequency: f64,
+    },
+    /// A generated S-parameter value had a non-finite real or imaginary component.
+    InvalidSParameterValue {
+        /// 0-based frequency point index.
+        point_index: usize,
+        /// Destination/output port, using 1-based RF indexing.
+        to_port: usize,
+        /// Source/input port, using 1-based RF indexing.
+        from_port: usize,
+        /// Real component.
+        re: f64,
+        /// Imaginary component.
+        im: f64,
+    },
+    /// A generated network reference impedance was not finite and positive.
+    InvalidReferenceImpedance {
+        /// Invalid reference impedance in ohms.
+        z0: f64,
+    },
 }
 
 impl TouchstoneError {
@@ -330,6 +391,64 @@ impl fmt::Display for TouchstoneError {
                 f,
                 "S-parameter port index S{to_port}{from_port} out of range for {rank}-port network"
             ),
+            Self::InvalidNetworkRank { rank } => {
+                write!(f, "invalid generated network rank: {rank}")
+            }
+            Self::NetworkRankExtensionMismatch {
+                rank,
+                extension_rank,
+            } => write!(
+                f,
+                "generated network rank {rank} does not match extension port count {extension_rank}"
+            ),
+            Self::EmptyNetworkData => write!(f, "generated network has no frequency points"),
+            Self::InvalidMatrixRank {
+                point_index,
+                matrix_rank,
+                expected_rank,
+            } => write!(
+                f,
+                "generated matrix at point {point_index} has rank {matrix_rank}, expected {expected_rank}"
+            ),
+            Self::InvalidMatrixShape {
+                point_index,
+                rows,
+                row_index,
+                columns,
+                expected_rank,
+            } => {
+                if let Some(row_index) = row_index {
+                    write!(
+                        f,
+                        "generated matrix at point {point_index} row {row_index} has {columns} columns, expected {expected_rank}"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "generated matrix at point {point_index} has {rows} rows, expected {expected_rank}"
+                    )
+                }
+            }
+            Self::InvalidFrequency {
+                point_index,
+                frequency,
+            } => write!(
+                f,
+                "generated frequency at point {point_index} is not finite: {frequency}"
+            ),
+            Self::InvalidSParameterValue {
+                point_index,
+                to_port,
+                from_port,
+                re,
+                im,
+            } => write!(
+                f,
+                "generated S{to_port}{from_port} at point {point_index} is not finite: ({re}, {im})"
+            ),
+            Self::InvalidReferenceImpedance { z0 } => {
+                write!(f, "generated reference impedance must be finite and positive: {z0}")
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! assert_eq!(net.rank, 2);
 //! ```
 
-use std::ops;
+use std::{io::Write, ops};
 /// Command-line interface helpers for the touchstone binary.
 pub mod cli;
 mod data_line;
@@ -21,6 +21,7 @@ mod data_pairs;
 mod error;
 mod file_extension;
 mod file_operations;
+mod network_builder;
 mod open;
 mod option_line;
 mod parser;
@@ -28,6 +29,7 @@ mod plot;
 mod utils;
 
 pub use error::{TouchstoneError, TouchstoneErrorContext, TouchstoneWarning};
+pub use network_builder::NetworkBuilder;
 
 /// A network parsed from a Touchstone (`.sNp`) file.
 ///
@@ -690,30 +692,30 @@ impl Network {
         );
     }
 
-    /// Save the network to a Touchstone file.
+    /// Serialize the network to an in-memory Touchstone string.
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// use touchstone::Network;
-    ///
-    /// let net = Network::new("files/ntwk1.s2p").unwrap();
-    /// let tmp = std::env::temp_dir().join("example_output.s2p");
-    /// net.save(tmp.to_str().unwrap()).unwrap();
-    /// std::fs::remove_file(tmp).unwrap();
-    /// ```
-    pub fn save(&self, file_path: &str) -> std::io::Result<()> {
-        use std::io::Write;
-        let mut file = std::fs::File::create(file_path)?;
+    /// The output matches [`save`](Self::save), including Touchstone 2.1 keywords and N-port
+    /// line wrapping.
+    pub fn to_touchstone_string(&self) -> std::io::Result<String> {
+        let mut bytes = Vec::new();
+        self.write_touchstone(&mut bytes)?;
+        String::from_utf8(bytes)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+    }
 
+    /// Write the network as Touchstone text to any [`std::io::Write`] destination.
+    ///
+    /// The writer auto-selects single-line format for 1-port and 2-port networks and multi-line
+    /// full-matrix format for 3-port and larger networks.
+    pub fn write_touchstone<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
         // Write comments
         for comment in &self.comments {
-            writeln!(file, "{}", comment)?;
+            writeln!(writer, "{}", comment)?;
         }
 
         let n = self.rank as usize;
 
-        writeln!(file, "[Version] 2.1")?;
+        writeln!(writer, "[Version] 2.1")?;
 
         // Write option line
         // # <frequency unit> <parameter> <format> R <n>
@@ -724,19 +726,19 @@ impl Network {
             self.resistance_string.clone(),
             self.z0.to_string().clone(),
         );
-        writeln!(file, "{}", option_line)?;
+        writeln!(writer, "{}", option_line)?;
 
-        writeln!(file, "[Number of Ports] {}", self.rank)?;
+        writeln!(writer, "[Number of Ports] {}", self.rank)?;
         if n == 2 {
-            writeln!(file, "[Two-Port Data Order] 21_12")?;
+            writeln!(writer, "[Two-Port Data Order] 21_12")?;
         }
-        writeln!(file, "[Number of Frequencies] {}", self.f.len())?;
-        writeln!(file, "[Matrix Format] Full")?;
-        writeln!(file, "[Network Data]")?;
+        writeln!(writer, "[Number of Frequencies] {}", self.f.len())?;
+        writeln!(writer, "[Matrix Format] Full")?;
+        writeln!(writer, "[Network Data]")?;
 
         // Keep existing post-option comments with the network data they describe.
         for comment in &self.comments_after_option_line {
-            writeln!(file, "{}", comment)?;
+            writeln!(writer, "{}", comment)?;
         }
 
         // Write data lines
@@ -795,7 +797,7 @@ impl Network {
                     _ => panic!("Unsupported format for saving: {}", self.format),
                 }
 
-                writeln!(file, "{}", line)?;
+                writeln!(writer, "{}", line)?;
             } else {
                 // Multi-line format for 3+ port
                 // First line: frequency and first row of S-parameters
@@ -808,7 +810,7 @@ impl Network {
                         for col in 1..=n {
                             line.push_str(&format!(" {} {}", s.get(1, col).0, s.get(1, col).1));
                         }
-                        writeln!(file, "{}", line)?;
+                        writeln!(writer, "{}", line)?;
 
                         // Subsequent rows on their own lines
                         for row in 2..=n {
@@ -820,7 +822,7 @@ impl Network {
                                     s.get(row, col).1
                                 ));
                             }
-                            writeln!(file, "{}", row_line)?;
+                            writeln!(writer, "{}", row_line)?;
                         }
                     }
                     "MA" => {
@@ -829,7 +831,7 @@ impl Network {
                         for col in 1..=n {
                             line.push_str(&format!(" {} {}", s.get(1, col).0, s.get(1, col).1));
                         }
-                        writeln!(file, "{}", line)?;
+                        writeln!(writer, "{}", line)?;
 
                         // Subsequent rows on their own lines
                         for row in 2..=n {
@@ -841,7 +843,7 @@ impl Network {
                                     s.get(row, col).1
                                 ));
                             }
-                            writeln!(file, "{}", row_line)?;
+                            writeln!(writer, "{}", row_line)?;
                         }
                     }
                     "DB" => {
@@ -850,7 +852,7 @@ impl Network {
                         for col in 1..=n {
                             line.push_str(&format!(" {} {}", s.get(1, col).0, s.get(1, col).1));
                         }
-                        writeln!(file, "{}", line)?;
+                        writeln!(writer, "{}", line)?;
 
                         // Subsequent rows on their own lines
                         for row in 2..=n {
@@ -862,7 +864,7 @@ impl Network {
                                     s.get(row, col).1
                                 ));
                             }
-                            writeln!(file, "{}", row_line)?;
+                            writeln!(writer, "{}", row_line)?;
                         }
                     }
                     _ => panic!("Unsupported format for saving: {}", self.format),
@@ -870,9 +872,26 @@ impl Network {
             }
         }
 
-        writeln!(file, "[End]")?;
+        writeln!(writer, "[End]")?;
 
         Ok(())
+    }
+
+    /// Save the network to a Touchstone file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use touchstone::Network;
+    ///
+    /// let net = Network::new("files/ntwk1.s2p").unwrap();
+    /// let tmp = std::env::temp_dir().join("example_output.s2p");
+    /// net.save(tmp.to_str().unwrap()).unwrap();
+    /// std::fs::remove_file(tmp).unwrap();
+    /// ```
+    pub fn save(&self, file_path: &str) -> std::io::Result<()> {
+        let file = std::fs::File::create(file_path)?;
+        self.write_touchstone(file)
     }
 }
 

--- a/src/network_builder.rs
+++ b/src/network_builder.rs
@@ -1,0 +1,327 @@
+use crate::data_line;
+use crate::data_pairs::{
+    DecibelAngle, DecibelAngleMatrix, MagnitudeAngle, MagnitudeAngleMatrix, RealImaginary,
+    RealImaginaryMatrix,
+};
+use crate::{Network, NetworkPoint, SMatrix, TouchstoneError};
+
+/// Builder for generated S-parameter networks.
+///
+/// Frequencies passed to [`point`](Self::point) and [`push_point`](Self::push_point) are in Hz.
+/// The `frequency_unit` setting controls how those frequencies are written when the network is
+/// serialized.
+///
+/// # Examples
+///
+/// ```
+/// use touchstone::{Complex, NetworkBuilder, SMatrix};
+///
+/// let network = NetworkBuilder::new("generated.s1p", 1)
+///     .point(
+///         1.0e9,
+///         SMatrix {
+///             rank: 1,
+///             data: vec![vec![Complex { re: 0.5, im: -0.1 }]],
+///         },
+///     )
+///     .build()?;
+///
+/// assert_eq!(network.rank, 1);
+/// assert_eq!(network.try_s_ri_at(0, 1, 1)?.re, 0.5);
+/// # Ok::<(), touchstone::TouchstoneError>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct NetworkBuilder {
+    name: String,
+    rank: usize,
+    frequency_unit: String,
+    z0: f64,
+    comments: Vec<String>,
+    comments_after_option_line: Vec<String>,
+    points: Vec<NetworkPoint>,
+}
+
+impl NetworkBuilder {
+    /// Create a builder for a generated S-parameter network.
+    ///
+    /// The default frequency unit is `Hz`, the default reference impedance is `50`, and the
+    /// serialized data format is `RI`.
+    #[must_use]
+    pub fn new<S: Into<String>>(name: S, rank: usize) -> Self {
+        Self {
+            name: name.into(),
+            rank,
+            frequency_unit: "Hz".to_string(),
+            z0: 50.0,
+            comments: Vec::new(),
+            comments_after_option_line: Vec::new(),
+            points: Vec::new(),
+        }
+    }
+
+    /// Set the frequency unit used when serializing the generated network.
+    ///
+    /// Frequencies added to the builder are always provided in Hz. Supported units are `Hz`,
+    /// `kHz`, `MHz`, `GHz`, and `THz`.
+    #[must_use]
+    pub fn frequency_unit<S: Into<String>>(mut self, frequency_unit: S) -> Self {
+        self.frequency_unit = frequency_unit.into();
+        self
+    }
+
+    /// Set the scalar reference impedance in ohms.
+    ///
+    /// The value must be finite and greater than zero.
+    #[must_use]
+    pub fn z0(mut self, z0: f64) -> Self {
+        self.z0 = z0;
+        self
+    }
+
+    /// Add a comment written before the option line.
+    ///
+    /// A leading `!` is added when the supplied text does not already start with one.
+    #[must_use]
+    pub fn comment<S: Into<String>>(mut self, comment: S) -> Self {
+        self.comments.push(normalize_comment(comment.into()));
+        self
+    }
+
+    /// Add a comment written inside the `[Network Data]` section before the first data point.
+    ///
+    /// A leading `!` is added when the supplied text does not already start with one.
+    #[must_use]
+    pub fn network_data_comment<S: Into<String>>(mut self, comment: S) -> Self {
+        self.comments_after_option_line
+            .push(normalize_comment(comment.into()));
+        self
+    }
+
+    /// Add one generated frequency point and return the builder.
+    ///
+    /// The frequency is in Hz. Matrix rows are destination/output ports and columns are
+    /// source/input ports.
+    #[must_use]
+    pub fn point(mut self, frequency: f64, s: SMatrix) -> Self {
+        self.points.push(NetworkPoint { frequency, s });
+        self
+    }
+
+    /// Add one generated frequency point to an existing builder.
+    ///
+    /// The frequency is in Hz. Matrix rows are destination/output ports and columns are
+    /// source/input ports.
+    pub fn push_point(&mut self, frequency: f64, s: SMatrix) -> &mut Self {
+        self.points.push(NetworkPoint { frequency, s });
+        self
+    }
+
+    /// Build a [`Network`] without serializing or reparsing Touchstone text.
+    pub fn build(self) -> Result<Network, TouchstoneError> {
+        let rank = validate_rank(self.rank)?;
+        validate_extension_rank(&self.name, self.rank)?;
+        let frequency_unit = canonical_frequency_unit(&self.frequency_unit)
+            .ok_or_else(|| TouchstoneError::UnsupportedFrequencyUnit {
+                unit: self.frequency_unit.clone(),
+            })?
+            .to_string();
+
+        if !self.z0.is_finite() || self.z0 <= 0.0 {
+            return Err(TouchstoneError::InvalidReferenceImpedance { z0: self.z0 });
+        }
+
+        if self.points.is_empty() {
+            return Err(TouchstoneError::EmptyNetworkData);
+        }
+
+        for (point_index, point) in self.points.iter().enumerate() {
+            validate_frequency(point_index, point.frequency)?;
+            validate_matrix(point_index, self.rank, &point.s)?;
+        }
+
+        let f = self
+            .points
+            .iter()
+            .map(|point| point.frequency)
+            .collect::<Vec<_>>();
+        let s = self
+            .points
+            .iter()
+            .map(|point| parsed_data_line_from_matrix(point.frequency, &point.s))
+            .collect::<Vec<_>>();
+
+        Ok(Network {
+            name: self.name,
+            rank,
+            frequency_unit,
+            parameter: "S".to_string(),
+            format: "RI".to_string(),
+            resistance_string: "R".to_string(),
+            z0: self.z0,
+            comments: self.comments,
+            comments_after_option_line: self.comments_after_option_line,
+            warnings: Vec::new(),
+            f,
+            s,
+        })
+    }
+}
+
+fn validate_rank(rank: usize) -> Result<i32, TouchstoneError> {
+    if rank == 0 || rank > i32::MAX as usize {
+        return Err(TouchstoneError::InvalidNetworkRank { rank });
+    }
+
+    Ok(rank as i32)
+}
+
+fn validate_extension_rank(name: &str, rank: usize) -> Result<(), TouchstoneError> {
+    if let Some(extension_rank) = infer_touchstone_extension_rank(name) {
+        if extension_rank != rank {
+            return Err(TouchstoneError::NetworkRankExtensionMismatch {
+                rank,
+                extension_rank,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_frequency(point_index: usize, frequency: f64) -> Result<(), TouchstoneError> {
+    if frequency.is_finite() {
+        Ok(())
+    } else {
+        Err(TouchstoneError::InvalidFrequency {
+            point_index,
+            frequency,
+        })
+    }
+}
+
+fn validate_matrix(
+    point_index: usize,
+    expected_rank: usize,
+    matrix: &SMatrix,
+) -> Result<(), TouchstoneError> {
+    if matrix.rank != expected_rank {
+        return Err(TouchstoneError::InvalidMatrixRank {
+            point_index,
+            matrix_rank: matrix.rank,
+            expected_rank,
+        });
+    }
+
+    if matrix.data.len() != expected_rank {
+        return Err(TouchstoneError::InvalidMatrixShape {
+            point_index,
+            rows: matrix.data.len(),
+            row_index: None,
+            columns: 0,
+            expected_rank,
+        });
+    }
+
+    for (row_index, row) in matrix.data.iter().enumerate() {
+        if row.len() != expected_rank {
+            return Err(TouchstoneError::InvalidMatrixShape {
+                point_index,
+                rows: matrix.data.len(),
+                row_index: Some(row_index),
+                columns: row.len(),
+                expected_rank,
+            });
+        }
+
+        for (column_index, value) in row.iter().enumerate() {
+            if !value.re.is_finite() || !value.im.is_finite() {
+                return Err(TouchstoneError::InvalidSParameterValue {
+                    point_index,
+                    to_port: row_index + 1,
+                    from_port: column_index + 1,
+                    re: value.re,
+                    im: value.im,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parsed_data_line_from_matrix(frequency: f64, matrix: &SMatrix) -> data_line::ParsedDataLine {
+    let s_ri_data = matrix
+        .data
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|value| RealImaginary(value.re, value.im))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let s_ri = RealImaginaryMatrix::from_vec(s_ri_data.clone());
+
+    let s_db = DecibelAngleMatrix::from_vec(
+        s_ri_data
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .copied()
+                    .map(DecibelAngle::from_real_imaginary)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    let s_ma = MagnitudeAngleMatrix::from_vec(
+        s_ri_data
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .copied()
+                    .map(MagnitudeAngle::from_real_imaginary)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>(),
+    );
+
+    data_line::ParsedDataLine {
+        frequency,
+        s_ri,
+        s_db,
+        s_ma,
+    }
+}
+
+fn infer_touchstone_extension_rank(name: &str) -> Option<usize> {
+    let extension = name.rsplit_once('.')?.1;
+    if !extension.starts_with('s') || !extension.ends_with('p') {
+        return None;
+    }
+
+    let digits = &extension[1..extension.len() - 1];
+    if digits.is_empty() || digits.starts_with('0') || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    digits.parse::<usize>().ok()
+}
+
+fn canonical_frequency_unit(unit: &str) -> Option<&'static str> {
+    match unit.trim().to_ascii_lowercase().as_str() {
+        "hz" => Some("Hz"),
+        "khz" => Some("kHz"),
+        "mhz" => Some("MHz"),
+        "ghz" => Some("GHz"),
+        "thz" => Some("THz"),
+        _ => None,
+    }
+}
+
+fn normalize_comment(comment: String) -> String {
+    if comment.trim_start().starts_with('!') {
+        comment
+    } else {
+        format!("! {comment}")
+    }
+}

--- a/tests/network_builder.rs
+++ b/tests/network_builder.rs
@@ -1,0 +1,267 @@
+use touchstone::{Complex, Network, NetworkBuilder, SMatrix, TouchstoneError};
+
+fn c(re: f64, im: f64) -> Complex {
+    Complex { re, im }
+}
+
+fn matrix(rows: Vec<Vec<Complex>>) -> SMatrix {
+    SMatrix {
+        rank: rows.len(),
+        data: rows,
+    }
+}
+
+#[test]
+fn builds_one_port_network_with_comments_and_derived_data() {
+    let network = NetworkBuilder::new("generated.s1p", 1)
+        .comment("generated one-port")
+        .network_data_comment("measured in memory")
+        .z0(75.0)
+        .point(1.0e9, matrix(vec![vec![c(0.5, -0.25)]]))
+        .point(2.0e9, matrix(vec![vec![c(0.6, -0.35)]]))
+        .build()
+        .unwrap();
+
+    assert_eq!(network.name, "generated.s1p");
+    assert_eq!(network.rank, 1);
+    assert_eq!(network.frequency_unit, "Hz");
+    assert_eq!(network.format, "RI");
+    assert_eq!(network.z0, 75.0);
+    assert_eq!(network.f, vec![1.0e9, 2.0e9]);
+    assert!(network.warnings.is_empty());
+    assert_eq!(network.try_s_ri_at(1, 1, 1).unwrap(), c(0.6, -0.35));
+    assert!(network.s_ma(1, 1)[0].s_ma.magnitude().is_finite());
+    assert!(network.s_db(1, 1)[0].s_db.decibel().is_finite());
+
+    let serialized = network.to_touchstone_string().unwrap();
+    assert!(serialized.starts_with("! generated one-port\n[Version] 2.1\n"));
+    assert!(serialized.contains("[Network Data]\n! measured in memory\n"));
+}
+
+#[test]
+fn builds_two_port_network_with_21_12_order_and_roundtrips_from_str() {
+    let network = NetworkBuilder::new("generated.s2p", 2)
+        .frequency_unit("GHz")
+        .point(
+            1.0e9,
+            matrix(vec![
+                vec![c(0.11, 0.01), c(0.12, 0.03)],
+                vec![c(0.21, 0.02), c(0.22, 0.04)],
+            ]),
+        )
+        .build()
+        .unwrap();
+
+    let serialized = network.to_touchstone_string().unwrap();
+    assert!(serialized.contains("[Two-Port Data Order] 21_12\n"));
+
+    let data_line = serialized
+        .lines()
+        .find(|line| line.starts_with("1 "))
+        .expect("serialized two-port data line");
+    let values = data_line
+        .split_whitespace()
+        .map(|part| part.parse::<f64>().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        values,
+        vec![1.0, 0.11, 0.01, 0.21, 0.02, 0.12, 0.03, 0.22, 0.04]
+    );
+
+    let reparsed = Network::from_str("generated.s2p", &serialized).unwrap();
+    assert_eq!(reparsed.try_s_ri_at(0, 1, 2).unwrap(), c(0.12, 0.03));
+    assert_eq!(reparsed.try_s_ri_at(0, 2, 1).unwrap(), c(0.21, 0.02));
+}
+
+#[test]
+fn serializes_thz_frequency_unit() {
+    let network = NetworkBuilder::new("generated.s1p", 1)
+        .frequency_unit("THz")
+        .point(1.0e12, matrix(vec![vec![c(0.5, 0.0)]]))
+        .build()
+        .unwrap();
+
+    let serialized = network.to_touchstone_string().unwrap();
+
+    assert!(serialized.contains("# THz S RI R 50\n"));
+    assert!(serialized.contains("1 0.5 0\n"));
+}
+
+#[test]
+fn builds_three_port_network_with_multiline_full_matrix_output() {
+    let network = NetworkBuilder::new("generated.s3p", 3)
+        .point(
+            1.0e9,
+            matrix(vec![
+                vec![c(11.0, 0.1), c(12.0, 0.2), c(13.0, 0.3)],
+                vec![c(21.0, 0.4), c(22.0, 0.5), c(23.0, 0.6)],
+                vec![c(31.0, 0.7), c(32.0, 0.8), c(33.0, 0.9)],
+            ]),
+        )
+        .build()
+        .unwrap();
+
+    let serialized = network.to_touchstone_string().unwrap();
+    let lines = serialized.lines().collect::<Vec<_>>();
+    let data_index = lines
+        .iter()
+        .position(|line| *line == "[Network Data]")
+        .unwrap();
+
+    assert_eq!(lines[data_index + 1], "1000000000 11 0.1 12 0.2 13 0.3");
+    assert_eq!(lines[data_index + 2], " 21 0.4 22 0.5 23 0.6");
+    assert_eq!(lines[data_index + 3], " 31 0.7 32 0.8 33 0.9");
+    assert_eq!(lines[data_index + 4], "[End]");
+
+    let reparsed = Network::from_str("generated.s3p", &serialized).unwrap();
+    assert_eq!(reparsed.try_s_ri_at(0, 3, 2).unwrap(), c(32.0, 0.8));
+}
+
+#[test]
+fn save_matches_in_memory_serialization() {
+    let network = NetworkBuilder::new("generated.s2p", 2)
+        .point(
+            1.0e9,
+            matrix(vec![
+                vec![c(0.11, 0.01), c(0.12, 0.03)],
+                vec![c(0.21, 0.02), c(0.22, 0.04)],
+            ]),
+        )
+        .build()
+        .unwrap();
+    let temp_dir = std::env::temp_dir().join("touchstone_network_builder_tests");
+    std::fs::create_dir_all(&temp_dir).unwrap();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = temp_dir.join(format!("save_matches_in_memory_{nanos}.s2p"));
+
+    network.save(path.to_str().unwrap()).unwrap();
+    let saved = std::fs::read_to_string(&path).unwrap();
+
+    assert_eq!(saved, network.to_touchstone_string().unwrap());
+
+    std::fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn rejects_invalid_network_rank() {
+    let error = NetworkBuilder::new("generated.s0p", 0).build().unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidNetworkRank { rank: 0 }
+    ));
+}
+
+#[test]
+fn rejects_extension_rank_mismatch() {
+    let error = NetworkBuilder::new("generated.s2p", 1)
+        .point(1.0e9, matrix(vec![vec![c(0.5, 0.0)]]))
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::NetworkRankExtensionMismatch {
+            rank: 1,
+            extension_rank: 2
+        }
+    ));
+}
+
+#[test]
+fn rejects_empty_data() {
+    let error = NetworkBuilder::new("generated.s1p", 1).build().unwrap_err();
+
+    assert!(matches!(error, TouchstoneError::EmptyNetworkData));
+}
+
+#[test]
+fn rejects_matrix_rank_mismatch() {
+    let error = NetworkBuilder::new("generated.s2p", 2)
+        .point(1.0e9, matrix(vec![vec![c(0.5, 0.0)]]))
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidMatrixRank {
+            point_index: 0,
+            matrix_rank: 1,
+            expected_rank: 2
+        }
+    ));
+}
+
+#[test]
+fn rejects_matrix_shape_mismatch() {
+    let error = NetworkBuilder::new("generated.s2p", 2)
+        .point(
+            1.0e9,
+            SMatrix {
+                rank: 2,
+                data: vec![vec![c(0.5, 0.0)]],
+            },
+        )
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidMatrixShape {
+            point_index: 0,
+            rows: 1,
+            row_index: None,
+            columns: 0,
+            expected_rank: 2
+        }
+    ));
+}
+
+#[test]
+fn rejects_non_finite_frequency() {
+    let error = NetworkBuilder::new("generated.s1p", 1)
+        .point(f64::NAN, matrix(vec![vec![c(0.5, 0.0)]]))
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidFrequency { point_index: 0, frequency } if frequency.is_nan()
+    ));
+}
+
+#[test]
+fn rejects_non_finite_s_parameter_value() {
+    let error = NetworkBuilder::new("generated.s1p", 1)
+        .point(1.0e9, matrix(vec![vec![c(f64::INFINITY, 0.0)]]))
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidSParameterValue {
+            point_index: 0,
+            to_port: 1,
+            from_port: 1,
+            re,
+            im: 0.0,
+        } if re.is_infinite()
+    ));
+}
+
+#[test]
+fn rejects_non_positive_z0() {
+    let error = NetworkBuilder::new("generated.s1p", 1)
+        .z0(0.0)
+        .point(1.0e9, matrix(vec![vec![c(0.5, 0.0)]]))
+        .build()
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        TouchstoneError::InvalidReferenceImpedance { z0: 0.0 }
+    ));
+}


### PR DESCRIPTION
## Summary

- Add public `NetworkBuilder` for generated S-parameter networks.
- Add `to_touchstone_string()` and `write_touchstone()` for in-memory serialization.
- Make `save()` delegate to the shared Touchstone writer.
- Add builder validation for rank, extension mismatch, matrix shape/rank, finite frequency/value, positive z0, and empty data.
- Add generated-network builder tests and README examples.

Stacked on #69.
Closes #61

## Validation

- `just ci`
- `git diff --check`
