### PR TITLE
feat: preserve reference impedance metadata

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -182,6 +182,13 @@ pub enum TouchstoneError {
         /// Matrix format token from the keyword.
         format: String,
     },
+    /// `[Reference]` did not contain either one common value or one value per port.
+    InvalidReferenceImpedanceCount {
+        /// Number of ports in the network.
+        ports: usize,
+        /// Number of reference impedance values found.
+        actual: usize,
+    },
     /// A requested 0-based frequency point index was outside the parsed data range.
     InvalidPointIndex {
         /// Requested 0-based frequency point index.
@@ -254,7 +261,7 @@ pub enum TouchstoneError {
         /// Imaginary component.
         im: f64,
     },
-    /// A generated network reference impedance was not finite and positive.
+    /// A reference impedance was not finite and positive.
     InvalidReferenceImpedance {
         /// Invalid reference impedance in ohms.
         z0: f64,
@@ -376,6 +383,10 @@ impl fmt::Display for TouchstoneError {
             Self::UnsupportedMatrixFormat { format } => {
                 write!(f, "unsupported [Matrix Format] value: {format}")
             }
+            Self::InvalidReferenceImpedanceCount { ports, actual } => write!(
+                f,
+                "invalid [Reference] value count: expected 1 common value or {ports} per-port values, found {actual}"
+            ),
             Self::InvalidPointIndex {
                 point_index,
                 point_count,
@@ -447,7 +458,7 @@ impl fmt::Display for TouchstoneError {
                 "generated S{to_port}{from_port} at point {point_index} is not finite: ({re}, {im})"
             ),
             Self::InvalidReferenceImpedance { z0 } => {
-                write!(f, "generated reference impedance must be finite and positive: {z0}")
+                write!(f, "reference impedance must be finite and positive: {z0}")
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,25 @@ mod utils;
 pub use error::{TouchstoneError, TouchstoneErrorContext, TouchstoneWarning};
 pub use network_builder::NetworkBuilder;
 
+/// Reference impedance metadata for a Touchstone network.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ReferenceImpedance {
+    /// One common real reference impedance in ohms for every port.
+    Common(f64),
+    /// One real reference impedance in ohms per port, ordered by port number.
+    PerPort(Vec<f64>),
+}
+
+impl ReferenceImpedance {
+    pub(crate) fn scalar_compatibility_value(&self) -> f64 {
+        match self {
+            Self::Common(z0) => *z0,
+            Self::PerPort(values) => values[0],
+        }
+    }
+}
+
 /// A network parsed from a Touchstone (`.sNp`) file.
 ///
 /// Represents an N-port network with S-parameter data at multiple frequencies.
@@ -64,7 +83,12 @@ pub struct Network {
     /// Resistance keyword from the option line (typically `"R"`).
     pub resistance_string: String,
     /// Reference impedance in ohms (default 50 Ω).
+    ///
+    /// For per-port reference impedance metadata, this is the first port's impedance as a scalar
+    /// compatibility value. Use [`Network::reference_impedance`] for the complete model.
     pub z0: f64,
+    /// Complete reference impedance metadata for the network.
+    pub reference_impedance: ReferenceImpedance,
     /// Comment lines appearing before the option line.
     pub comments: Vec<String>,
     /// Comment lines appearing after the option line.
@@ -286,6 +310,18 @@ impl Network {
         }
     }
 
+    /// Return complete reference impedance metadata for this network.
+    ///
+    /// Existing scalar callers can continue to use [`Network::z0`]. When the network has a common
+    /// reference impedance, this method reflects the current `z0` value.
+    #[must_use]
+    pub fn reference_impedance(&self) -> ReferenceImpedance {
+        match &self.reference_impedance {
+            ReferenceImpedance::Common(_) => ReferenceImpedance::Common(self.z0),
+            ReferenceImpedance::PerPort(values) => ReferenceImpedance::PerPort(values.clone()),
+        }
+    }
+
     /// Return the frequency vector in Hz.
     ///
     /// # Examples
@@ -501,10 +537,13 @@ impl Network {
             panic!("Cascading is only implemented for 2-port networks. Use cascade_ports() for explicit port specification.");
         }
 
-        if self.z0 != other.z0 {
+        let self_z0 = common_reference_impedance_or_panic(self);
+        let other_z0 = common_reference_impedance_or_panic(other);
+
+        if self_z0 != other_z0 {
             panic!(
                 "Cannot cascade networks with different reference impedances: {} and {}",
-                self.z0, other.z0
+                self_z0, other_z0
             );
         }
 
@@ -567,16 +606,16 @@ impl Network {
             let s1 = &self.s[i].s_ri;
             let s2 = &other.s[i].s_ri;
 
-            let abcd1 = s1.to_abcd(self.z0);
-            let abcd2 = s2.to_abcd(other.z0);
+            let abcd1 = s1.to_abcd(self_z0);
+            let abcd2 = s2.to_abcd(other_z0);
 
             let abcd_new = abcd1 * abcd2;
 
             // Resulting Z0? Usually the Z0 of the output port of the second network,
             // but for S-parameters of the cascaded block, we usually reference the input port of the first
             // and output port of the second.
-            // If Z0 is the same for both (checked at start of function), then it's just self.z0.
-            let s_new_ri = abcd_new.to_s(self.z0);
+            // If Z0 is the same for both (checked at start of function), then it's just self_z0.
+            let s_new_ri = abcd_new.to_s(self_z0);
 
             let s_new_ma = crate::data_pairs::MagnitudeAngleMatrix::from_vec(vec![
                 vec![
@@ -607,7 +646,8 @@ impl Network {
             parameter: self.parameter.clone(),
             format: self.format.clone(),
             resistance_string: self.resistance_string.clone(),
-            z0: self.z0,
+            z0: self_z0,
+            reference_impedance: ReferenceImpedance::Common(self_z0),
             comments,
             comments_after_option_line,
             warnings: [self.warnings.clone(), other.warnings.clone()].concat(),
@@ -731,6 +771,9 @@ impl Network {
         writeln!(writer, "[Number of Ports] {}", self.rank)?;
         if n == 2 {
             writeln!(writer, "[Two-Port Data Order] 21_12")?;
+        }
+        if let ReferenceImpedance::PerPort(values) = self.reference_impedance() {
+            writeln!(writer, "[Reference] {}", format_real_values(&values))?;
         }
         writeln!(writer, "[Number of Frequencies] {}", self.f.len())?;
         writeln!(writer, "[Matrix Format] Full")?;
@@ -905,6 +948,14 @@ fn full_matrix_data_order(n: usize) -> Vec<(usize, usize)> {
     }
 }
 
+fn format_real_values(values: &[f64]) -> String {
+    values
+        .iter()
+        .map(f64::to_string)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn complex_from_real_imaginary(value: data_pairs::RealImaginary) -> Complex {
     Complex {
         re: value.0,
@@ -926,6 +977,17 @@ fn validate_port_indexes(
     }
 
     Ok(())
+}
+
+fn common_reference_impedance_or_panic(network: &Network) -> f64 {
+    match network.reference_impedance() {
+        ReferenceImpedance::Common(z0) => z0,
+        ReferenceImpedance::PerPort(_) => {
+            panic!(
+                "Cannot cascade networks with per-port reference impedances; common scalar reference impedance is required"
+            );
+        }
+    }
 }
 
 // The `std::ops::Mul` trait is used to specify the functionality of `+`.

--- a/src/network_builder.rs
+++ b/src/network_builder.rs
@@ -3,7 +3,7 @@ use crate::data_pairs::{
     DecibelAngle, DecibelAngleMatrix, MagnitudeAngle, MagnitudeAngleMatrix, RealImaginary,
     RealImaginaryMatrix,
 };
-use crate::{Network, NetworkPoint, SMatrix, TouchstoneError};
+use crate::{Network, NetworkPoint, ReferenceImpedance, SMatrix, TouchstoneError};
 
 /// Builder for generated S-parameter networks.
 ///
@@ -158,6 +158,7 @@ impl NetworkBuilder {
             format: "RI".to_string(),
             resistance_string: "R".to_string(),
             z0: self.z0,
+            reference_impedance: ReferenceImpedance::Common(self.z0),
             comments: self.comments,
             comments_after_option_line: self.comments_after_option_line,
             warnings: Vec::new(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,9 @@ use crate::data_line;
 use crate::file_extension;
 use crate::option_line;
 use crate::utils;
-use crate::{Network, TouchstoneError, TouchstoneErrorContext, TouchstoneWarning};
+use crate::{
+    Network, ReferenceImpedance, TouchstoneError, TouchstoneErrorContext, TouchstoneWarning,
+};
 
 #[derive(Debug)]
 struct ParserState {
@@ -12,6 +14,8 @@ struct ParserState {
     option_line_parsed: bool,
     two_port_data_order: data_line::TwoPortDataOrder,
     expected_number_of_frequencies: Option<usize>,
+    reference_impedance: Option<ReferenceImpedance>,
+    pending_reference_line: Option<(usize, String)>,
 }
 
 #[cfg(test)]
@@ -45,6 +49,8 @@ pub fn parse_str(source_name: &str, contents: &str) -> Result<Network, Touchston
         data_lines: Vec::new(),
         two_port_data_order: data_line::TwoPortDataOrder::default(),
         expected_number_of_frequencies: None,
+        reference_impedance: None,
+        pending_reference_line: None,
     };
 
     let mut comment_lines: Vec<String> = Vec::new();
@@ -83,6 +89,31 @@ pub fn parse_str(source_name: &str, contents: &str) -> Result<Network, Touchston
         let is_option_line = trimmed_line.starts_with("#");
         let is_comment = trimmed_line.starts_with("!");
         let is_keyword = trimmed_line.starts_with("[");
+
+        if parser_state.pending_reference_line.is_some() && !is_comment && !trimmed_line.is_empty()
+        {
+            let (reference_line_number, reference_line) =
+                parser_state.pending_reference_line.as_ref().unwrap();
+            if is_keyword || is_option_line {
+                return Err(TouchstoneError::InvalidReferenceImpedanceCount {
+                    ports: n_ports as usize,
+                    actual: 0,
+                }
+                .with_context(TouchstoneErrorContext {
+                    source_name: source_name.to_string(),
+                    line_number: Some(*reference_line_number),
+                    line: Some(reference_line.clone()),
+                }));
+            }
+
+            let line_without_comment = trimmed_line.split('!').next().unwrap_or("").trim();
+            parser_state.reference_impedance = Some(
+                parse_reference_impedance(line_without_comment, n_ports as usize)
+                    .map_err(|error| with_line_context(error, source_name, line_number, line))?,
+            );
+            parser_state.pending_reference_line = None;
+            continue;
+        }
 
         if is_option_line {
             if !parser_state.option_line_parsed {
@@ -214,6 +245,46 @@ pub fn parse_str(source_name: &str, contents: &str) -> Result<Network, Touchston
         reference_resistance = parsed_options.reference_resistance.clone();
     }
 
+    if let Some((line_number, line)) = &parser_state.pending_reference_line {
+        return Err(TouchstoneError::InvalidReferenceImpedanceCount {
+            ports: n_ports as usize,
+            actual: 0,
+        }
+        .with_context(TouchstoneErrorContext {
+            source_name: source_name.to_string(),
+            line_number: Some(*line_number),
+            line: Some(line.clone()),
+        }));
+    }
+
+    let option_line_z0 = utils::try_str_to_f64(reference_resistance.as_str()).map_err(|error| {
+        if let Some((line_number, line)) = &option_line_location {
+            with_line_context(error, source_name, *line_number, line)
+        } else {
+            error.with_context(TouchstoneErrorContext {
+                source_name: source_name.to_string(),
+                line_number: None,
+                line: None,
+            })
+        }
+    })?;
+    validate_reference_impedance_value(option_line_z0).map_err(|error| {
+        if let Some((line_number, line)) = &option_line_location {
+            with_line_context(error, source_name, *line_number, line)
+        } else {
+            error.with_context(TouchstoneErrorContext {
+                source_name: source_name.to_string(),
+                line_number: None,
+                line: None,
+            })
+        }
+    })?;
+
+    let reference_impedance = parser_state
+        .reference_impedance
+        .unwrap_or(ReferenceImpedance::Common(option_line_z0));
+    let z0 = reference_impedance.scalar_compatibility_value();
+
     tracing::debug!(
         num_ports = n_ports,
         num_frequencies = f.len(),
@@ -229,17 +300,8 @@ pub fn parse_str(source_name: &str, contents: &str) -> Result<Network, Touchston
         parameter,
         format,
         resistance_string,
-        z0: utils::try_str_to_f64(reference_resistance.as_str()).map_err(|error| {
-            if let Some((line_number, line)) = &option_line_location {
-                with_line_context(error, source_name, *line_number, line)
-            } else {
-                error.with_context(TouchstoneErrorContext {
-                    source_name: source_name.to_string(),
-                    line_number: None,
-                    line: None,
-                })
-            }
-        })?,
+        z0,
+        reference_impedance,
         comments: comment_lines,
         comments_after_option_line,
         warnings,
@@ -317,6 +379,15 @@ fn handle_keyword_line(
                     }
                 })?);
         }
+        "reference" => {
+            if argument.is_empty() {
+                parser_state.pending_reference_line = Some((line_number, line.to_string()));
+            } else {
+                parser_state.reference_impedance =
+                    Some(parse_reference_impedance(argument, n_ports as usize)?);
+                parser_state.pending_reference_line = None;
+            }
+        }
         "network data" => {}
         "matrix format" => {
             if !argument.eq_ignore_ascii_case("Full") {
@@ -334,6 +405,42 @@ fn handle_keyword_line(
     }
 
     Ok(false)
+}
+
+fn parse_reference_impedance(
+    argument: &str,
+    n_ports: usize,
+) -> Result<ReferenceImpedance, TouchstoneError> {
+    let values = argument
+        .split_whitespace()
+        .map(utils::try_str_to_f64)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    match values.len() {
+        1 => {
+            let z0 = values[0];
+            validate_reference_impedance_value(z0)?;
+            Ok(ReferenceImpedance::Common(z0))
+        }
+        count if count == n_ports => {
+            for value in &values {
+                validate_reference_impedance_value(*value)?;
+            }
+            Ok(ReferenceImpedance::PerPort(values))
+        }
+        actual => Err(TouchstoneError::InvalidReferenceImpedanceCount {
+            ports: n_ports,
+            actual,
+        }),
+    }
+}
+
+fn validate_reference_impedance_value(z0: f64) -> Result<(), TouchstoneError> {
+    if z0.is_finite() && z0 > 0.0 {
+        Ok(())
+    } else {
+        Err(TouchstoneError::InvalidReferenceImpedance { z0 })
+    }
 }
 
 fn normalize_keyword(keyword: &str) -> String {

--- a/tests/generated_network_contracts.rs
+++ b/tests/generated_network_contracts.rs
@@ -19,6 +19,10 @@ fn round_trip_from_string(network: &Network) -> Network {
 fn assert_round_trip_points(network: &Network) {
     let reparsed = round_trip_from_string(network);
 
+    assert_eq!(
+        reparsed.reference_impedance(),
+        network.reference_impedance()
+    );
     assert_eq!(reparsed.points().unwrap(), network.points().unwrap());
 }
 

--- a/tests/in_memory_network.rs
+++ b/tests/in_memory_network.rs
@@ -1,8 +1,10 @@
 use std::fs;
 
-use touchstone::{Network, TouchstoneError, TouchstoneWarning};
+use touchstone::{Network, ReferenceImpedance, TouchstoneError, TouchstoneWarning};
 
 const TWO_PORT_RI: &str = "# GHz S RI R 50\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n";
+const THREE_PORT_RI_DATA: &str =
+    "1.0 0.11 0.0 0.12 0.0 0.13 0.0 0.21 0.0 0.22 0.0 0.23 0.0 0.31 0.0 0.32 0.0 0.33 0.0\n";
 
 #[test]
 fn new_reads_existing_touchstone_file() {
@@ -24,6 +26,121 @@ fn from_str_parses_uploaded_touchstone_data_without_file() {
     assert_eq!(network.f, vec![1.0e9]);
     assert_eq!(network.s_ri(2, 1)[0].s_ri.0, 4.0);
     assert_eq!(network.s_ri(1, 2)[0].s_ri.0, 0.01);
+}
+
+#[test]
+fn from_str_reports_common_reference_impedance_from_option_line() {
+    let network = Network::from_str("uploaded.s1p", "# GHz S RI R 75\n1.0 0.5 0.0\n").unwrap();
+
+    assert_eq!(network.z0, 75.0);
+    assert_eq!(
+        network.reference_impedance(),
+        ReferenceImpedance::Common(75.0)
+    );
+}
+
+#[test]
+fn from_str_parses_common_reference_keyword_over_option_line() {
+    let network = Network::from_str(
+        "uploaded.s2p",
+        "[Version] 2.1\n# GHz S RI R 50\n[Number of Ports] 2\n[Reference] 75\n[Network Data]\n1.0 0.1 0.0 4.0 0.0 0.01 0.0 0.2 0.0\n[End]\n",
+    )
+    .unwrap();
+
+    assert_eq!(network.z0, 75.0);
+    assert_eq!(
+        network.reference_impedance(),
+        ReferenceImpedance::Common(75.0)
+    );
+}
+
+#[test]
+fn from_str_parses_per_port_reference_keyword() {
+    let contents = format!(
+        "[Version] 2.1\n# GHz S RI R 50\n[Number of Ports] 3\n[Reference]\n45 50 55\n[Network Data]\n{THREE_PORT_RI_DATA}[End]\n"
+    );
+
+    let network = Network::from_str("uploaded.s3p", &contents).unwrap();
+
+    assert_eq!(network.z0, 45.0);
+    assert_eq!(
+        network.reference_impedance(),
+        ReferenceImpedance::PerPort(vec![45.0, 50.0, 55.0])
+    );
+}
+
+#[test]
+fn to_touchstone_string_round_trips_per_port_reference_keyword() {
+    let contents = format!(
+        "[Version] 2.1\n# GHz S RI R 50\n[Number of Ports] 3\n[Reference] 45 50 55\n[Network Data]\n{THREE_PORT_RI_DATA}[End]\n"
+    );
+    let network = Network::from_str("uploaded.s3p", &contents).unwrap();
+
+    let serialized = network.to_touchstone_string().unwrap();
+    assert!(serialized.contains("[Reference] 45 50 55\n"));
+
+    let reparsed = Network::from_str("uploaded.s3p", &serialized).unwrap();
+    assert_eq!(reparsed.z0, 45.0);
+    assert_eq!(
+        reparsed.reference_impedance(),
+        ReferenceImpedance::PerPort(vec![45.0, 50.0, 55.0])
+    );
+    assert_eq!(reparsed.points().unwrap(), network.points().unwrap());
+}
+
+#[test]
+fn from_str_rejects_reference_keyword_count_mismatch() {
+    let contents = format!(
+        "[Version] 2.1\n# GHz S RI R 50\n[Number of Ports] 3\n[Reference] 45 50\n[Network Data]\n{THREE_PORT_RI_DATA}[End]\n"
+    );
+
+    let error = Network::from_str("uploaded.s3p", &contents).unwrap_err();
+
+    assert!(matches!(
+        error.root_cause(),
+        TouchstoneError::InvalidReferenceImpedanceCount {
+            ports: 3,
+            actual: 2
+        }
+    ));
+    assert_eq!(error.context().unwrap().line_number, Some(4));
+}
+
+#[test]
+fn from_str_reports_missing_reference_following_line_at_reference_keyword() {
+    let contents = format!(
+        "[Version] 2.1\n# GHz S RI R 50\n[Reference]\n[Network Data]\n{THREE_PORT_RI_DATA}[End]\n"
+    );
+
+    let error = Network::from_str("uploaded.s3p", &contents).unwrap_err();
+
+    assert!(matches!(
+        error.root_cause(),
+        TouchstoneError::InvalidReferenceImpedanceCount {
+            ports: 3,
+            actual: 0
+        }
+    ));
+    assert_eq!(error.context().unwrap().line_number, Some(3));
+    assert_eq!(
+        error.context().unwrap().line.as_deref(),
+        Some("[Reference]")
+    );
+}
+
+#[test]
+fn from_str_rejects_non_positive_reference_keyword_value() {
+    let error = Network::from_str(
+        "uploaded.s1p",
+        "[Version] 2.1\n# GHz S RI R 50\n[Reference] 0\n[Network Data]\n1.0 0.5 0.0\n[End]\n",
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error.root_cause(),
+        TouchstoneError::InvalidReferenceImpedance { z0: 0.0 }
+    ));
+    assert_eq!(error.context().unwrap().line_number, Some(3));
 }
 
 #[test]
@@ -153,6 +270,11 @@ fn assert_same_network_shape(path: &str, left: &Network, right: &Network) {
     assert_eq!(left.format, right.format, "{path}");
     assert_eq!(left.resistance_string, right.resistance_string, "{path}");
     assert_eq!(left.z0, right.z0, "{path}");
+    assert_eq!(
+        left.reference_impedance(),
+        right.reference_impedance(),
+        "{path}"
+    );
     assert_eq!(left.comments, right.comments, "{path}");
     assert_eq!(
         left.comments_after_option_line, right.comments_after_option_line,

--- a/tests/network_builder.rs
+++ b/tests/network_builder.rs
@@ -1,4 +1,4 @@
-use touchstone::{Complex, Network, NetworkBuilder, SMatrix, TouchstoneError};
+use touchstone::{Complex, Network, NetworkBuilder, ReferenceImpedance, SMatrix, TouchstoneError};
 
 fn c(re: f64, im: f64) -> Complex {
     Complex { re, im }
@@ -27,6 +27,10 @@ fn builds_one_port_network_with_comments_and_derived_data() {
     assert_eq!(network.frequency_unit, "Hz");
     assert_eq!(network.format, "RI");
     assert_eq!(network.z0, 75.0);
+    assert_eq!(
+        network.reference_impedance(),
+        ReferenceImpedance::Common(75.0)
+    );
     assert_eq!(network.f, vec![1.0e9, 2.0e9]);
     assert!(network.warnings.is_empty());
     assert_eq!(network.try_s_ri_at(1, 1, 1).unwrap(), c(0.6, -0.35));
@@ -35,6 +39,7 @@ fn builds_one_port_network_with_comments_and_derived_data() {
 
     let serialized = network.to_touchstone_string().unwrap();
     assert!(serialized.starts_with("! generated one-port\n[Version] 2.1\n"));
+    assert!(!serialized.contains("[Reference]"));
     assert!(serialized.contains("[Network Data]\n! measured in memory\n"));
 }
 

--- a/tests/s2p_coverage.rs
+++ b/tests/s2p_coverage.rs
@@ -132,6 +132,11 @@ fn assert_same_parse(path: &str, left: &Network, right: &Network) {
     assert_eq!(left.format, right.format, "{path}");
     assert_eq!(left.resistance_string, right.resistance_string, "{path}");
     assert_eq!(left.z0, right.z0, "{path}");
+    assert_eq!(
+        left.reference_impedance(),
+        right.reference_impedance(),
+        "{path}"
+    );
     assert_eq!(left.comments, right.comments, "{path}");
     assert_eq!(
         left.comments_after_option_line, right.comments_after_option_line,


### PR DESCRIPTION
## Summary

- Add public `ReferenceImpedance` metadata with common and per-port variants.
- Parse Touchstone v2 `[Reference]` keyword values inline or on the following line.
- Preserve scalar `network.z0` compatibility while exposing complete metadata.
- Serialize per-port reference impedance metadata on write.
- Add parser, round-trip, builder, and fixture comparison tests.

Stacked on #71.

## Linked Issue

Closes iancleary/touchstone#65

## Validation

- `just ci`
- `git diff --check`
