### PR TITLE
Add crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,11 @@ description = "Touchstone (s2p, etc.) file parser, plotter, and more"
 documentation = "https://docs.rs/touchstone"
 edition = "2021"
 homepage = "https://github.com/iancleary/touchstone"
+keywords = ["touchstone", "s-parameters", "rf", "parser", "plotting"]
+categories = ["command-line-utilities", "parser-implementations", "science", "visualization"]
 license = "MIT"
 name = "touchstone"
+readme = "README.md"
 repository = "https://github.com/iancleary/touchstone"
 version = "0.14.0"
 


### PR DESCRIPTION
## Summary

- Add crates.io-facing metadata to `Cargo.toml`: keywords, categories, and explicit README.
- Leave code unchanged; this is a packaging and discoverability polish PR.

## Checks run

- `cargo fmt --all -- --check` - pass
- `cargo clippy --all-targets --all-features -- -D warnings` - pass
- `cargo test --all-features` - pass
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features` - pass
- `cargo package --list` - pass
- `cargo package` - pass, including verification
- `cargo build` - pass

## Notes/risks

- `just ci` was not run locally because `just` is not installed in this environment; all underlying `just ci` commands were run directly.
- Optional tools `cargo-audit`, `cargo-deny`, `cargo-machete`, and `cargo-semver-checks` were not installed locally, so those checks were skipped.
