### PR TITLE
Add touchstone agent usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,29 @@
-# CLAUDE.md — touchstone
+# AGENTS.md - touchstone
 
 ## Overview
 
 Rust crate for parsing, analyzing, and writing Touchstone (SNP) files — the industry-standard format for S-parameter data. Supports 1-port through N-port (tested to 32-port), all data formats (RI/MA/DB), generated networks, interpolation/resampling, reference impedance metadata, network parameter conversions, and 2-port network cascading via ABCD parameters. Published on crates.io; current release target is v0.14.1.
+
+## Agent Usage
+
+Use `touchstone` whenever the task starts from measured or simulated
+S-parameter data: `.s1p`, `.s2p`, `.s3p`, `.sNp` parsing, plotting, resampling,
+reference impedance metadata, S/Y/Z/ABCD conversion, or cascading two-port
+networks. Create a `Network` with `Network::new`, `Network::from_str`, or
+`Network::from_bytes`; use `NetworkBuilder` only when generating synthetic
+network data in memory.
+
+Do not use this crate for scalar dBm/noise/wavelength conversion; use
+`rfconversions`. Do not use it for block-level gain/NF/P1dB/IP3 lineup
+modeling unless S-parameter files are the source of the stages; use
+`gainlineup` for block cascades. Use `linkbudget` when the question is about
+end-to-end link margin, BER, modulation, orbit, Doppler, or regulatory PFD.
+
+Important conventions for agents: S-parameter port indices are 1-indexed
+(`s_db(2, 1)` is S21), parsed frequencies are stored in Hz, and interpolation is
+performed on real/imaginary components before rebuilding magnitude/angle or
+dB/angle views. Preserve parser warnings for non-fatal file issues instead of
+discarding them.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,27 @@
 
 Rust crate for parsing, analyzing, and writing Touchstone (SNP) files — the industry-standard format for S-parameter data. Supports 1-port through N-port (tested to 32-port), all data formats (RI/MA/DB), generated networks, interpolation/resampling, reference impedance metadata, network parameter conversions, and 2-port network cascading via ABCD parameters. Published on crates.io; current release target is v0.14.1.
 
+## Agent Usage
+
+Use `touchstone` whenever the task starts from measured or simulated
+S-parameter data: `.s1p`, `.s2p`, `.s3p`, `.sNp` parsing, plotting, resampling,
+reference impedance metadata, S/Y/Z/ABCD conversion, or cascading two-port
+networks. Create a `Network` with `Network::new`, `Network::from_str`, or
+`Network::from_bytes`; use `NetworkBuilder` only when generating synthetic
+network data in memory.
+
+Do not use this crate for scalar dBm/noise/wavelength conversion; use
+`rfconversions`. Do not use it for block-level gain/NF/P1dB/IP3 lineup
+modeling unless S-parameter files are the source of the stages; use
+`gainlineup` for block cascades. Use `linkbudget` when the question is about
+end-to-end link margin, BER, modulation, orbit, Doppler, or regulatory PFD.
+
+Important conventions for agents: S-parameter port indices are 1-indexed
+(`s_db(2, 1)` is S21), parsed frequencies are stored in Hz, and interpolation is
+performed on real/imaginary components before rebuilding magnitude/angle or
+dB/angle views. Preserve parser warnings for non-fatal file issues instead of
+discarding them.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ Touchstone (SNP) parser for RF Engineering — Full N-Port Support
 
 Parse, analyze, and manipulate Touchstone files with any number of ports (1-port, 2-port, 3-port, 4-port, and beyond).
 
+## When To Use This Crate
+
+Use `touchstone` when the task starts from measured or simulated S-parameter
+data: `.s1p`, `.s2p`, `.sNp` parsing/writing, plotting, resampling,
+reference-impedance metadata, S/Y/Z/ABCD conversion, or two-port network
+cascading.
+
+If the task is scalar RF unit math, use `rfconversions`. If it is a block-level
+gain/NF/P1dB/IP3 lineup, use `gainlineup`. If it is an end-to-end radio link
+question involving EIRP, path loss, C/No, Eb/No, BER, margin, orbit, Doppler,
+PFD, or modulation, use `linkbudget`.
+
+S-parameter port indices are 1-indexed: `s_db(2, 1)` is S21. Parsed frequencies
+are stored in Hz, and interpolation is performed in real/imaginary space before
+rebuilding magnitude/angle or dB/angle views.
+
 ## Installation
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,14 @@
 //! A Rust library for parsing, manipulating, and plotting Touchstone (`.sNp`) files
 //! containing S-parameter data for RF and microwave networks.
 //!
+//! Use `touchstone` for measured or simulated S-parameter files, network
+//! resampling, reference impedance metadata, S/Y/Z/ABCD conversion, and two-port
+//! network cascading. Use `rfconversions` for scalar RF math, `gainlineup` for
+//! block-level gain/NF/P1dB/IP3 lineups, and `linkbudget` for end-to-end radio
+//! link performance.
+//!
+//! S-parameter port indices are 1-indexed: `s_db(2, 1)` is S21.
+//!
 //! # Examples
 //!
 //! ```


### PR DESCRIPTION
## Summary

- add touchstone-specific Agent Usage guidance to AGENTS.md and CLAUDE.md
- mirror the crate-selection guidance in README.md and crate-level docs for dependency consumers
- fix the AGENTS.md title so it is not labeled as CLAUDE.md
- document when agents should use touchstone versus rfconversions, gainlineup, or linkbudget
- capture 1-indexed S-parameter ports, Hz frequency storage, interpolation behavior, and parser warning handling

## Verification

- `cargo fmt -- --check`
- `cargo test`