### PR TITLE
docs: add crate status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # touchstone
 
+[![Crates.io](https://img.shields.io/crates/v/touchstone.svg)](https://crates.io/crates/touchstone)
+[![Docs.rs](https://docs.rs/touchstone/badge.svg)](https://docs.rs/touchstone)
+
 Touchstone (SNP) parser for RF Engineering — Full N-Port Support
 
 Parse, analyze, and manipulate Touchstone files with any number of ports (1-port, 2-port, 3-port, 4-port, and beyond).


### PR DESCRIPTION
## Summary

- add crates.io and docs.rs badges to the README header
- align touchstone's crate-discovery links with the sibling Rust crate READMEs

## Checks run

- `just ci` passed locally, including `fmt-check`, `lint`, `test`, `doc-check`, `package`, and release build
- `cargo package --list` inspected package contents
- checked `https://crates.io/crates/touchstone` and `https://docs.rs/touchstone/latest/touchstone/`

## Notes/risks

- README-only change; no code behavior changes.
- The local shell profile emitted `/tmp/openclaw-rust-prs/cargo/env: No such file or directory` during command startup, but the repo checks still completed successfully.
